### PR TITLE
Gromacs modified recipe + spec

### DIFF
--- a/setonix/environments/env_apps/spack.yaml
+++ b/setonix/environments/env_apps/spack.yaml
@@ -6,7 +6,7 @@ spack:
     - amber@20 +openmp
     - cpmd@4.3 +mpi +omp
     - cp2k@8.1 +plumed ^plumed@2.7.2 ^python@3.9.7+optimizations
-    - gromacs@2021.2 +double +lapack +plumed ^plumed@2.7.2 ^python@3.9.7+optimizations
+    - gromacs@2021.4 +double +lapack +plumed ^plumed@2.7.2 ^python@3.9.7+optimizations
     - lammps@20210929 +asphere +body +class2 +colloid +compress +coreshell +dipole
       +ffmpeg +granular +jpeg +kim +kokkos +kspace +latte +manybody +mc +misc +mliap
       +molecule +mpiio +opt +peri +png +poems +python +qeq +replica +rigid +shock

--- a/setonix/repo_setonix/packages/gromacs/gmxDetectCpu-cmake-3.14.patch
+++ b/setonix/repo_setonix/packages/gromacs/gmxDetectCpu-cmake-3.14.patch
@@ -1,0 +1,12 @@
+--- a/cmake/gmxDetectCpu.cmake
++++ b/cmake/gmxDetectCpu.cmake
+@@ -83,7 +83,7 @@ function(gmx_run_cpu_detection TYPE)
+                 set(GCC_INLINE_ASM_DEFINE "-DGMX_X86_GCC_INLINE_ASM=0")
+             endif()
+ 
+-            set(_compile_definitions "${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}")
++            set(_compile_definitions ${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})
+             set(LINK_LIBRARIES "${GMX_STDLIB_LIBRARIES}")
+             try_compile(CPU_DETECTION_COMPILED
+                 "${PROJECT_BINARY_DIR}"
+

--- a/setonix/repo_setonix/packages/gromacs/gmxDetectSimd-cmake-3.14.patch
+++ b/setonix/repo_setonix/packages/gromacs/gmxDetectSimd-cmake-3.14.patch
@@ -1,0 +1,11 @@
+--- a/cmake/gmxDetectSimd.cmake
++++ b/cmake/gmxDetectSimd.cmake
+@@ -77,7 +77,7 @@ function(gmx_suggest_simd _suggested_simd)
+     else()
+         set(GMX_TARGET_X86_VALUE 0)
+     endif()
+-    set(_compile_definitions "${GCC_INLINE_ASM_DEFINE} -I${CMAKE_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}")
++    set(_compile_definitions ${GCC_INLINE_ASM_DEFINE} -I${CMAKE_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})
+ 
+     # Prepare a default suggestion
+     set(OUTPUT_SIMD "None")

--- a/setonix/repo_setonix/packages/gromacs/package.py
+++ b/setonix/repo_setonix/packages/gromacs/package.py
@@ -1,0 +1,418 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+
+class Gromacs(CMakePackage):
+    """GROMACS (GROningen MAchine for Chemical Simulations) is a molecular
+    dynamics package primarily designed for simulations of proteins, lipids
+    and nucleic acids. It was originally developed in the Biophysical
+    Chemistry department of University of Groningen, and is now maintained
+    by contributors in universities and research centers across the world.
+
+    GROMACS is one of the fastest and most popular software packages
+    available and can run on CPUs as well as GPUs. It is free, open source
+    released under the GNU General Public License. Starting from version 4.6,
+    GROMACS is released under the GNU Lesser General Public License.
+    """
+
+    homepage = 'http://www.gromacs.org'
+    url      = 'https://ftp.gromacs.org/gromacs/gromacs-5.1.2.tar.gz'
+    git      = 'https://github.com/gromacs/gromacs.git'
+    maintainers = ['junghans', 'marvinbernhardt']
+
+    version('master', branch='master')
+    version('2021.3', sha256='e109856ec444768dfbde41f3059e3123abdb8fe56ca33b1a83f31ed4575a1cc6')
+    version('2021.2', sha256='d940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb')
+    version('2021.1', sha256='bc1d0a75c134e1fb003202262fe10d3d32c59bbb40d714bc3e5015c71effe1e5')
+    version('2021', sha256='efa78ab8409b0f5bf0fbca174fb8fbcf012815326b5c71a9d7c385cde9a8f87b')
+    version('2020.6', sha256='d8bbe57ed3c9925a8cb99ecfe39e217f930bed47d5268a9e42b33da544bdb2ee')
+    version('2020.5', sha256='7b6aff647f7c8ee1bf12204d02cef7c55f44402a73195bd5f42cf11850616478')
+    version('2020.4', sha256='5519690321b5500c7951aaf53ff624042c3edd1a5f5d6dd1f2d802a3ecdbf4e6')
+    version('2020.3', sha256='903183691132db14e55b011305db4b6f4901cc4912d2c56c131edfef18cc92a9')
+    version('2020.2', sha256='7465e4cd616359d84489d919ec9e4b1aaf51f0a4296e693c249e83411b7bd2f3')
+    version('2020.1', sha256='e1666558831a3951c02b81000842223698016922806a8ce152e8f616e29899cf')
+    version('2020', sha256='477e56142b3dcd9cb61b8f67b24a55760b04d1655e8684f979a75a5eec40ba01')
+    version('2019.6', sha256='bebe396dc0db11a9d4cc205abc13b50d88225617642508168a2195324f06a358')
+    version('2019.5', sha256='438061a4a2d45bbb5cf5c3aadd6c6df32d2d77ce8c715f1c8ffe56156994083a')
+    version('2019.4', sha256='ba4366eedfc8a1dbf6bddcef190be8cd75de53691133f305a7f9c296e5ca1867')
+    version('2019.3', sha256='4211a598bf3b7aca2b14ad991448947da9032566f13239b1a05a2d4824357573')
+    version('2019.2', sha256='bcbf5cc071926bc67baa5be6fb04f0986a2b107e1573e15fadcb7d7fc4fb9f7e')
+    version('2019.1', sha256='b2c37ed2fcd0e64c4efcabdc8ee581143986527192e6e647a197c76d9c4583ec')
+    version('2019', sha256='c5b281a5f0b5b4eeb1f4c7d4dc72f96985b566561ca28acc9c7c16f6ee110d0b')
+    version('2018.8', sha256='776923415df4bc78869d7f387c834141fdcda930b2e75be979dc59ecfa6ebecf')
+    version('2018.5', sha256='32261df6f7ec4149fc0508f9af416953d056e281590359838c1ed6644ba097b8')
+    version('2018.4', sha256='6f2ee458c730994a8549d6b4f601ecfc9432731462f8bd4ffa35d330d9aaa891')
+    version('2018.3', sha256='4423a49224972969c52af7b1f151579cea6ab52148d8d7cbae28c183520aa291')
+    version('2018.2', sha256='4bdde8120c510b6543afb4b18f82551fddb11851f7edbd814aa24022c5d37857')
+    version('2018.1', sha256='4d3533340499323fece83b4a2d4251fa856376f2426c541e00b8e6b4c0d705cd')
+    version('2018',   sha256='deb5d0b749a52a0c6083367b5f50a99e08003208d81954fb49e7009e1b1fd0e9')
+    version('2016.6', sha256='bac0117d2cad21f9b94fe5b854fb9ae7435b098a6da4e732ee745f18e52473d7')
+    version('2016.5', sha256='57db26c6d9af84710a1e0c47a1f5bf63a22641456448dcd2eeb556ebd14e0b7c')
+    version('2016.4', sha256='4be9d3bfda0bdf3b5c53041e0b8344f7d22b75128759d9bfa9442fe65c289264')
+    version('2016.3', sha256='7bf00e74a9d38b7cef9356141d20e4ba9387289cbbfd4d11be479ef932d77d27')
+    version('5.1.5',  sha256='c25266abf07690ecad16ed3996899b1d489cbb1ef733a1befb3b5c75c91a703e')
+    version('5.1.4',  sha256='0f3793d8f1f0be747cf9ebb0b588fb2b2b5dc5acc32c3046a7bee2d2c03437bc')
+    version('5.1.2',  sha256='39d6f1d7ae8ba38cea6089da40676bfa4049a49903d21551abc030992a58f304')
+    version('4.6.7', sha256='6afb1837e363192043de34b188ca3cf83db6bd189601f2001a1fc5b0b2a214d9')
+    version('4.5.5', sha256='e0605e4810b0d552a8761fef5540c545beeaf85893f4a6e21df9905a33f871ba')
+
+    variant('mpi', default=True, description='Activate MPI support (disable for Thread-MPI support)')
+    variant('shared', default=True,
+            description='Enables the build of shared libraries')
+    variant(
+        'double', default=False,
+        description='Produces a double precision version of the executables')
+    variant('plumed', default=False, description='Enable PLUMED support')
+    variant('cuda', default=False, description='Enable CUDA support')
+    variant('opencl', default=False, description='Enable OpenCL support')
+    variant('sycl', default=False, description='Enable SYCL support')
+    variant('nosuffix', default=False, description='Disable default suffixes')
+    variant('build_type', default='RelWithDebInfo',
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel',
+                    'Reference', 'RelWithAssert', 'Profile'))
+    variant('mdrun_only', default=False,
+            description='Enables the build of a cut-down version'
+            ' of libgromacs and/or the mdrun program')
+    conflicts('+mdrun_only', when='@2021:',
+              msg='mdrun-only build option was removed for GROMACS 2021.')
+    variant('openmp', default=True,
+            description='Enables OpenMP at configure time')
+    variant('relaxed_double_precision', default=False,
+            description='GMX_RELAXED_DOUBLE_PRECISION, use only for Fujitsu PRIMEHPC')
+    conflicts('+relaxed_double_precision', when='@2021:',
+              msg='GMX_RELAXED_DOUBLE_PRECISION option removed for GROMACS 2021.')
+    variant('hwloc', default=True,
+            description='Use the hwloc portable hardware locality library')
+    variant('lapack', default=False,
+            description='Enables an external LAPACK library')
+    variant('blas', default=False,
+            description='Enables an external BLAS library')
+    variant('cycle_subcounters', default=False,
+            description='Enables cycle subcounters')
+
+    depends_on('mpi', when='+mpi')
+
+    # Plumed 2.7.2 needs Gromacs 2021, 2020.6, 2019.6
+    # Plumed 2.7.1 needs Gromacs 2021, 2020.5, 2019.6
+    # Plumed 2.7.0 needs Gromacs       2020.4, 2019.6
+    # Plumed 2.6.3 needs Gromacs       2020.4, 2019.6, 2018.8
+    # Plumed 2.6.2 needs Gromacs       2020.4, 2019.6, 2018.8
+    # Plumed 2.6.1 needs Gromacs       2020.2, 2019.6, 2018.8
+    # Plumed 2.6.0 needs Gromacs               2019.4, 2018.8
+    # Plumed 2.5.7 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.6 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.5 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.4 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.3 needs Gromacs               2019.4, 2018.8, 2016.6
+    # Plumed 2.5.2 needs Gromacs               2019.2, 2018.6, 2016.6
+    # Plumed 2.5.1 needs Gromacs                       2018.6, 2016.6
+    # Plumed 2.5.0 needs Gromacs                       2018.4, 2016.5
+
+    # Above dependencies can be verified, and new versions added, by going to
+    # https://github.com/plumed/plumed2/tree/v2.7.1/patches
+    # and switching tags.
+
+    depends_on('plumed+mpi', when='+plumed+mpi')
+    depends_on('plumed~mpi', when='+plumed~mpi')
+    depends_on('plumed@2.6.1:2.7.2+mpi', when='@2021.4+plumed+mpi')
+    depends_on('plumed@2.6.1:2.7.2+mpi', when='@2021+plumed+mpi')
+    depends_on('plumed@2.7.1:2.7.2~mpi', when='@2021+plumed~mpi')
+    depends_on('plumed@2.7.2+mpi', when='@2020.6+plumed+mpi')
+    depends_on('plumed@2.7.2~mpi', when='@2020.6+plumed~mpi')
+    depends_on('plumed@2.7.1+mpi', when='@2020.5+plumed+mpi')
+    depends_on('plumed@2.7.1~mpi', when='@2020.5+plumed~mpi')
+    depends_on('plumed@2.6.2:2.7.0+mpi', when='@2020.4+plumed+mpi')
+    depends_on('plumed@2.6.2:2.7.0~mpi', when='@2020.4+plumed~mpi')
+    depends_on('plumed@2.6.1+mpi', when='@2020.2+plumed+mpi')
+    depends_on('plumed@2.6.1~mpi', when='@2020.2+plumed~mpi')
+    depends_on('plumed@2.6.1:2.7.1+mpi', when='@2019.6+plumed+mpi')
+    depends_on('plumed@2.6.1:2.7.1~mpi', when='@2019.6+plumed~mpi')
+    depends_on('plumed@2.5.3:2.6.0+mpi', when='@2019.4+plumed+mpi')
+    depends_on('plumed@2.5.3:2.6.0~mpi', when='@2019.4+plumed~mpi')
+    depends_on('plumed@2.5.2+mpi', when='@2019.2+plumed+mpi')
+    depends_on('plumed@2.5.2~mpi', when='@2019.2+plumed~mpi')
+    depends_on('plumed@2.5.3:2.6+mpi', when='@2018.8+plumed+mpi')
+    depends_on('plumed@2.5.3:2.6~mpi', when='@2018.8+plumed~mpi')
+    depends_on('plumed@2.5.1:2.5.2+mpi', when='@2018.6+plumed+mpi')
+    depends_on('plumed@2.5.1:2.5.2~mpi', when='@2018.6+plumed~mpi')
+    depends_on('plumed@2.5.0+mpi', when='@2018.4+plumed+mpi')
+    depends_on('plumed@2.5.0~mpi', when='@2018.4+plumed~mpi')
+    depends_on('plumed@2.5.1:2.5+mpi', when='@2016.6+plumed+mpi')
+    depends_on('plumed@2.5.1:2.5~mpi', when='@2016.6+plumed~mpi')
+    depends_on('plumed@2.5.0+mpi', when='@2016.5+plumed+mpi')
+    depends_on('plumed@2.5.0~mpi', when='@2016.5+plumed~mpi')
+
+    depends_on('fftw-api@3')
+    depends_on('cmake@2.8.8:3', type='build')
+    depends_on('cmake@3.4.3:3', type='build', when='@2018:')
+    depends_on('cmake@3.9.6:3', type='build', when='@2020')
+    depends_on('cmake@3.13.0:3', type='build', when='@2021:')
+    depends_on('cmake@3.16.0:3', type='build', when='@master')
+    depends_on('cmake@3.16.0:3', type='build', when='%fj')
+    depends_on('cuda', when='+cuda')
+    depends_on('sycl', when='+sycl')
+    depends_on('lapack', when='+lapack')
+    depends_on('blas', when='+blas')
+
+    depends_on('hwloc@1.0:1', when='+hwloc@2016:2018')
+    depends_on('hwloc', when='+hwloc@2019:')
+
+    patch('gmxDetectCpu-cmake-3.14.patch', when='@2018:2019.3^cmake@3.14.0:')
+    patch('gmxDetectSimd-cmake-3.14.patch', when='@5.0:2017^cmake@3.14.0:')
+
+    filter_compiler_wrappers(
+        '*.cmake',
+        relative_root=os.path.join('share', 'cmake', 'gromacs_mpi'))
+    filter_compiler_wrappers(
+        '*.cmake',
+        relative_root=os.path.join('share', 'cmake', 'gromacs'))
+
+    def patch(self):
+        # Otherwise build fails with GCC 11 (11.2)
+        if self.spec.satisfies('@2018:2020.6'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/awh/biasparams.h')
+        if self.spec.satisfies('@2018:2018.8'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/mdlib/minimize.cpp')
+        if self.spec.satisfies('@2019:2019.6,2020:2020.6'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/mdrun/minimize.cpp')
+        if self.spec.satisfies('@2020:2020.6'):
+            filter_file('#include <queue>', '#include <queue>\n#include <limits>',
+                        'src/gromacs/modularsimulator/modularsimulator.h')
+
+        if '+plumed' in self.spec:
+            self.spec['plumed'].package.apply_patch(self)
+
+        if self.spec.satisfies('%nvhpc'):
+            # Disable obsolete workaround
+            filter_file('ifdef __PGI', 'if 0', 'src/gromacs/fileio/xdrf.h')
+
+        if '+cuda' in self.spec:
+            # Upstream supports building of last two major versions of Gromacs.
+            # Older versions of Gromacs need to be patched to build with more recent
+            # versions of CUDA library.
+
+            # Hardware version 3.0 is supported up to CUDA 10.2 (Gromacs 4.6-2020.3
+            # needs to be patched, 2020.4 is handling it correctly)
+
+            if self.spec.satisfies('@4.6:2020.3^cuda@11:'):
+                filter_file(r'-gencode;arch=compute_30,code=sm_30;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+                filter_file(r'-gencode;arch=compute_30,code=compute_30;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+
+            # Hardware version 2.0 is supported up to CUDA 8 (Gromacs 4.6-2016.3
+            # needs to be patched, 2016.4 is handling it correctly, removed in 2019)
+
+            if self.spec.satisfies('@4.6:2016.3^cuda@9:'):
+                filter_file(r'-gencode;arch=compute_20,code=sm_20;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+                filter_file(r'-gencode;arch=compute_20,code=compute_20;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+
+            if self.spec.satisfies('@4.6:5.0^cuda@9:'):
+                filter_file(r'-gencode;arch=compute_20,code=sm_21;?', '',
+                            'cmake/gmxManageNvccConfig.cmake')
+
+    def cmake_args(self):
+
+        options = []
+
+        if '+mpi' in self.spec:
+            options.append('-DGMX_MPI:BOOL=ON')
+            if self.version < Version('2020'):
+                # Ensures gmxapi builds properly
+                options.extend([
+                    '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+                    '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+                    '-DCMAKE_Fortran_COMPILER=%s' % self.spec['mpi'].mpifc,
+                ])
+            elif self.version == Version('2021'):
+                # Work around https://gitlab.com/gromacs/gromacs/-/issues/3896
+                # Ensures gmxapi builds properly
+                options.extend([
+                    '-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+                    '-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx,
+                ])
+            else:
+                options.extend([
+                    '-DCMAKE_C_COMPILER=%s' % spack_cc,
+                    '-DCMAKE_CXX_COMPILER=%s' % spack_cxx,
+                    '-DMPI_C_COMPILER=%s' % self.spec['mpi'].mpicc,
+                    '-DMPI_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx
+                ])
+        else:
+            options.extend([
+                '-DCMAKE_C_COMPILER=%s' % spack_cc,
+                '-DCMAKE_CXX_COMPILER=%s' % spack_cxx,
+                '-DGMX_MPI:BOOL=OFF',
+                '-DGMX_THREAD_MPI:BOOL=ON'])
+
+        if self.spec.satisfies('@2020:'):
+            options.append('-DGMX_INSTALL_LEGACY_API=ON')
+
+        if '+double' in self.spec:
+            options.append('-DGMX_DOUBLE:BOOL=ON')
+
+        if '+nosuffix' in self.spec:
+            options.append('-DGMX_DEFAULT_SUFFIX:BOOL=OFF')
+
+        if '~shared' in self.spec:
+            options.append('-DBUILD_SHARED_LIBS:BOOL=OFF')
+            options.append('-DGMXAPI:BOOL=OFF')
+
+        if '+hwloc' in self.spec:
+            options.append('-DGMX_HWLOC:BOOL=ON')
+        else:
+            options.append('-DGMX_HWLOC:BOOL=OFF')
+
+        if self.version >= Version('2021'):
+            if '+cuda' in self.spec:
+                options.append('-DGMX_GPU:STRING=CUDA')
+            elif '+opencl' in self.spec:
+                options.append('-DGMX_GPU:STRING=OpenCL')
+            elif '+sycl' in self.spec:
+                options.append('-DGMX_GPU:STRING=SYCL')
+            else:
+                options.append('-DGMX_GPU:STRING=OFF')
+        else:
+            if '+cuda' in self.spec or '+opencl' in self.spec:
+                options.append('-DGMX_GPU:BOOL=ON')
+            else:
+                options.append('-DGMX_GPU:BOOL=OFF')
+
+        if '+cuda' in self.spec:
+            options.append('-DCUDA_TOOLKIT_ROOT_DIR:STRING=' +
+                           self.spec['cuda'].prefix)
+
+        if '+opencl' in self.spec:
+            options.append('-DGMX_USE_OPENCL=on')
+
+        if '+lapack' in self.spec:
+            options.append('-DGMX_EXTERNAL_LAPACK:BOOL=ON')
+            if self.spec['lapack'].libs:
+                options.append('-DGMX_LAPACK_USER={0}'.format(
+                    self.spec['lapack'].libs.joined(';')))
+        else:
+            options.append('-DGMX_EXTERNAL_LAPACK:BOOL=OFF')
+
+        if '+blas' in self.spec:
+            options.append('-DGMX_EXTERNAL_BLAS:BOOL=ON')
+            if self.spec['blas'].libs:
+                options.append('-DGMX_BLAS_USER={0}'.format(
+                    self.spec['blas'].libs.joined(';')))
+        else:
+            options.append('-DGMX_EXTERNAL_BLAS:BOOL=OFF')
+
+        # Activate SIMD based on properties of the target
+        target = self.spec.target
+        if target >= 'zen2':
+            # AMD Family 17h (EPYC Rome)
+            options.append('-DGMX_SIMD=AVX2_256')
+        elif target >= 'zen':
+            # AMD Family 17h (EPYC Naples)
+            options.append('-DGMX_SIMD=AVX2_128')
+        elif target >= 'bulldozer':
+            # AMD Family 15h
+            options.append('-DGMX_SIMD=AVX_128_FMA')
+        elif 'vsx' in target:
+            # IBM Power 7 and beyond
+            if self.spec.satisfies('%nvhpc'):
+                options.append('-DGMX_SIMD=None')
+            else:
+                options.append('-DGMX_SIMD=IBM_VSX')
+        elif target.family == 'aarch64':
+            # ARMv8
+            if self.spec.satisfies('%nvhpc'):
+                options.append('-DGMX_SIMD=None')
+            else:
+                options.append('-DGMX_SIMD=ARM_NEON_ASIMD')
+        elif target == 'mic_knl':
+            # Intel KNL
+            options.append('-DGMX_SIMD=AVX_512_KNL')
+        else:
+            # Other architectures
+            simd_features = [
+                ('sse2', 'SSE2'),
+                ('sse4_1', 'SSE4.1'),
+                ('avx', 'AVX_256'),
+                ('axv128', 'AVX2_128'),
+                ('avx2', 'AVX2_256'),
+                ('avx512', 'AVX_512'),
+            ]
+
+            # Workaround NVIDIA compiler bug when avx512 is enabled
+            if (self.spec.satisfies('%nvhpc') and
+                ('avx512', 'AVX_512') in simd_features):
+                simd_features.remove(('avx512', 'AVX_512'))
+
+            feature_set = False
+            for feature, flag in reversed(simd_features):
+                if feature in target:
+                    options.append('-DGMX_SIMD:STRING={0}'.format(flag))
+                    feature_set = True
+                    break
+
+            # Fall back
+            if not feature_set:
+                options.append('-DGMX_SIMD:STRING=None')
+
+        # Use the 'rtdscp' assembly instruction only on
+        # appropriate architectures
+        options.append(self.define(
+            'GMX_USE_RDTSCP', str(target.family) in ('x86_64', 'x86')
+        ))
+
+        if self.spec.satisfies('@:2020'):
+            options.append(
+                self.define_from_variant('GMX_BUILD_MDRUN_ONLY', 'mdrun_only'))
+
+        options.append(self.define_from_variant('GMX_OPENMP', 'openmp'))
+
+        if self.spec.satisfies('@:2020'):
+            options.append(
+                self.define_from_variant(
+                    'GMX_RELAXED_DOUBLE_PRECISION',
+                    'relaxed_double_precision'))
+
+        if '+cycle_subcounters' in self.spec:
+            options.append('-DGMX_CYCLE_SUBCOUNTERS:BOOL=ON')
+        else:
+            options.append('-DGMX_CYCLE_SUBCOUNTERS:BOOL=OFF')
+
+        if '^mkl' in self.spec:
+            # fftw-api@3 is provided by intel-mkl or intel-parllel-studio
+            # we use the mkl interface of gromacs
+            options.append('-DGMX_FFT_LIBRARY=mkl')
+            options.append('-DMKL_INCLUDE_DIR={0}'.
+                           format(self.spec['mkl'].headers.directories[0]))
+            # The 'blas' property provides a minimal set of libraries
+            # that is sufficient for fft. Using full mkl fails the cmake test
+            options.append('-DMKL_LIBRARIES={0}'.
+                           format(self.spec['blas'].libs.joined(';')))
+        else:
+            # we rely on the fftw-api@3
+            options.append('-DGMX_FFT_LIBRARY=fftw3')
+            if '^amdfftw' in self.spec:
+                options.append('-DGMX_FFT_LIBRARY=fftw3')
+                options.append(
+                    '-DFFTWF_INCLUDE_DIRS={0}'.
+                    format(self.spec['amdfftw'].headers.directories[0])
+                )
+                options.append('-DFFTWF_LIBRARIES={0}'.
+                               format(self.spec['amdfftw'].libs.joined(';')))
+
+        # Ensure that the GROMACS log files report how the code was patched
+        # during the build, so that any problems are easier to diagnose.
+        if '+plumed' in self.spec:
+            options.append('-DGMX_VERSION_STRING_OF_FORK=PLUMED-spack')
+        else:
+            options.append('-DGMX_VERSION_STRING_OF_FORK=spack')
+        return options

--- a/setonix/repo_setonix/packages/plumed/package.py
+++ b/setonix/repo_setonix/packages/plumed/package.py
@@ -1,0 +1,224 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import collections
+import os.path
+
+
+class Plumed(AutotoolsPackage):
+    """PLUMED is an open source library for free energy calculations in
+    molecular systems which works together with some of the most popular
+    molecular dynamics engines.
+
+    Free energy calculations can be performed as a function of many order
+    parameters with a particular focus on biological problems, using state
+    of the art methods such as metadynamics, umbrella sampling and
+    Jarzynski-equation based steered MD.
+
+    The software, written in C++, can be easily interfaced with both fortran
+    and C/C++ codes.
+    """
+    homepage = 'https://www.plumed.org/'
+    url = 'https://github.com/plumed/plumed2/archive/v2.6.3.tar.gz'
+    git = 'https://github.com/plumed/plumed2.git'
+
+    version('master', branch='master')
+    version('2.7.2', sha256='c9a31e68d6440828cf186ca43c9e11a5e5c7ad1c96b2b66ed5a5a141fc954373')
+    version('2.7.1', sha256='cb8b5735d8dd61980fa6441f3dde3f33544240ae4177da0f529fb5abb355cd4a')
+    version('2.7.0', sha256='14450ea566c25ac9bf71fd77bb9c0c95e9038462b5739c73a515be82e2011cd6')
+    version('2.6.3', preferred=True, sha256='d05b9e4a4c1329fc932d5bdd04f20419be230f98159bdc012a91716461ab4a2f')
+    version('2.6.2', sha256='bbc2ef0cb08d404513b8b737c72333b6656389e15effd6a0f9ace2a5758c9a4a')
+    version('2.6.1', sha256='c1b3c397b2d971140aa240dde50e48a04ce78e3dedb02b6dca80fa53f8026e4e')
+    version('2.6.0', sha256='3d57ae460607a49547ef38a52c4ac93493a3966857c352280a9c05f5dcdb1820')
+    version('2.5.7', sha256='aa10d2879c3edeaef9d5a530fe8b05f67ecfbec2e9423e0f95701d0bc54826c7')
+    version('2.5.6', sha256='1bc29b0274196fb553cdf7ba8ecb7a93a91d60a920d99863edbcd536d618ce8c')
+    version('2.5.5', sha256='70faa9ff1938e286dc388cb793b39840953e5646855b684f48df1bc864b737e8')
+    version('2.5.4', sha256='a1647e598191f261e75d06351e607475d395af481315052a4c28563ac9989a7f')
+    version('2.5.3', sha256='543288be667dc4201fc461ecd2dd4878ddfbeac682d0c021c99ea8e501c7c9dc')
+    version('2.5.2', sha256='85d10cc46e2e37c7719cf51c0931278f56c2c8f8a9d86188b2bf97c2535a2ab4')
+    version('2.5.1', sha256='de309980dcfd6f6e0e70e138856f4bd9eb4d8a513906a5e6389f18a5af7f2eba')
+    version('2.5.0', sha256='53e08187ec9f8af2326fa84407e34644a7c51d2af93034309fb70675eee5e4f7')
+    version('2.4.6', sha256='c22ad19f5cd36ce9fe4ba0b53158fc2a3d985c48fc04606e3f3b3e835b994cb3')
+    version('2.4.4', sha256='1e5c24109314481fad404da97d61c7339b219e27e120c9c80bacc79c9f6a51a8')
+    version('2.4.2', sha256='528ce57f1f5330480bcd403140166a4580efd2acaea39c85dfeca5e2cd649321')
+    version('2.4.1', sha256='f00410ebdd739c2ddf55fcd714ff4bd88a1029e02d2fc9cea0b5fca34e0fc4eb')
+    version('2.3.5', sha256='a6a66ca4582c1aecc6138c96be015e13cd06a718e8446b2f13e610fe34602e4f')
+    version('2.3.3', sha256='ac058ff529f207d5b4169fb5a87bdb3c77307dfef1ac543ad8b6c74c5de7fc91')
+    version('2.3.0', sha256='b1c8a54a313a0569e27e36420770074f35406453f73de70e55c424652abeddf1')
+    version('2.2.4', sha256='d7a1dba34a7fe03f23e8d39ab6e15b230c4851373fdceb3602e2de26ea53ce37')
+    version('2.2.3', sha256='2db19c5f6a2918833941d0bf47b5431d0865529d786df797ccc966d763ed7b0c')
+
+    # Variants. PLUMED by default builds a number of optional modules.
+    # The ones listed here are not built by default for various reasons,
+    # such as stability, lack of testing, or lack of demand.
+    # FIXME: This needs to be an optional
+    variant(
+        'optional_modules',
+        default='all',
+        values=lambda x: True,
+        description='String that is used to build optional modules'
+    )
+    variant('shared', default=True, description='Builds shared libraries')
+    variant('mpi', default=True, description='Activates MPI support')
+    variant('gsl', default=True, description='Activates GSL support')
+    variant('arrayfire', default='none',
+            values=('none', 'cpu', 'cuda', 'opencl'),
+            description='Activates FireArray support')
+
+    # Dependencies. LAPACK and BLAS are recommended but not essential.
+    depends_on('zlib')
+    depends_on('blas')
+    depends_on('lapack')
+    # For libmatheval support through the 'function' module
+    # which is enabled by default (or when optional_modules=all)
+    depends_on('libmatheval', when='@:2.4')
+    depends_on('arrayfire', when='arrayfire=cpu')
+    depends_on('arrayfire+cuda', when='arrayfire=cuda')
+    depends_on('arrayfire+opencl', when='arrayfire=opencl')
+
+    depends_on('mpi', when='+mpi')
+    depends_on('gsl', when='+gsl')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+    depends_on('m4', type='build')
+    depends_on('py-cython', type='build', when='@2.5:')
+
+    force_autoreconf = True
+
+    parallel = False
+
+    def apply_patch(self, other):
+
+        # The name of MD engines differ slightly from the ones used in Spack
+        format_strings = collections.defaultdict(
+            lambda: '{0.name}-{0.version}'
+        )
+        format_strings['espresso'] = 'q{0.name}-{0.version}'
+        format_strings['amber'] = '{0.name}{0.version}'
+
+        get_md = lambda x: format_strings[x.name].format(x)
+
+        # Get available patches
+        plumed_patch = Executable(
+            os.path.join(self.spec.prefix.bin, 'plumed-patch')
+        )
+
+        out = plumed_patch('-q', '-l', output=str)
+        available = out.split(':')[-1].split()
+        if self.spec.satisfies('@2.6.1:2.7.2'): available.extend(["gromacs-2021", "gromacs-2021.4"]) 
+	
+        # Check that `other` is among the patchable applications
+        if get_md(other) not in available:
+            msg = '{0.name}@{0.version} is not among the MD engine'
+            msg += ' that can be patched by {1.name}@{1.version}.\n'
+            msg += 'Supported engines are:\n'
+            for x in available:
+                msg += x + '\n'
+            raise RuntimeError(msg.format(other, self.spec))
+
+        # Call plumed-patch to patch executables
+        target = format_strings[other.name].format(other)
+        plumed_patch('-p', '-e', target)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        # Make plumed visible from dependent packages
+        module.plumed = dependent_spec['plumed'].command
+
+    @property
+    def plumed_inc(self):
+        return os.path.join(
+            self.prefix.lib, 'plumed', 'src', 'lib', 'Plumed.inc'
+        )
+
+    @run_before('autoreconf')
+    def filter_gslcblas(self):
+        # This part is needed to avoid linking with gsl cblas
+        # interface which will mask the cblas interface
+        # provided by optimized libraries due to linking order
+        filter_file('-lgslcblas', '', 'configure.ac')
+
+    def patch(self):
+        # Ensure Spack's wrappers are used to compile the Python interface
+        env = 'CXX={0} LDSHARED="{0} -pthread -shared" ' \
+              'LDCXXSHARED="{0} -pthread -shared"'.format(spack_cxx)
+        filter_file('plumed_program_name=plumed',
+                    '{0} plumed_program_name=plumed'.format(env),
+                    'src/lib/Makefile', 'python/Makefile')
+
+    def configure_args(self):
+        spec = self.spec
+
+        # From plumed docs :
+        # Also consider that this is different with respect to what some other
+        # configure script does in that variables such as MPICXX are
+        # completely ignored here. In case you work on a machine where CXX is
+        # set to a serial compiler and MPICXX to a MPI compiler, to compile
+        # with MPI you should use:
+        #
+        # > ./configure CXX="$MPICXX"
+
+        # The configure.ac script may detect the wrong linker for
+        # LD_RO which causes issues at link time. Here we work around
+        # the issue saying we have no LD_RO executable.
+        configure_opts = ['--disable-ld-r']
+
+        # If using MPI then ensure the correct compiler wrapper is used.
+        if '+mpi' in spec:
+            configure_opts.extend([
+                '--enable-mpi',
+                'CXX={0}'.format(spec['mpi'].mpicxx)
+            ])
+
+            # If the MPI dependency is provided by the intel-mpi package then
+            # the following additional argument is required to allow it to
+            # build.
+            if 'intel-mpi' in spec:
+                configure_opts.extend([
+                    'STATIC_LIBS=-mt_mpi'
+                ])
+
+        extra_libs = []
+        # Set flags to help find gsl
+        if '+gsl' in spec:
+            gsl_libs = spec['gsl'].libs
+            blas_libs = spec['blas'].libs
+            extra_libs.append(
+                (gsl_libs + blas_libs).ld_flags
+            )
+        # Set flags to help with ArrayFire
+        if 'arrayfire=none' not in spec:
+            libaf = 'arrayfire:{0}'.format(spec.variants['arrayfire'].value)
+            extra_libs.append(spec[libaf].libs.search_flags)
+
+        if extra_libs:
+            configure_opts.append('LDFLAGS={0}'.format(
+                ' '.join(extra_libs)
+            ))
+
+        # Additional arguments
+        configure_opts.extend([
+            '--enable-shared={0}'.format('yes' if '+shared' in spec else 'no'),
+            '--enable-gsl={0}'.format('yes' if '+gsl' in spec else 'no'),
+            '--enable-af_cpu={0}'.format('yes' if 'arrayfire=cpu' in spec else 'no'),
+            '--enable-af_cuda={0}'.format('yes' if 'arrayfire=cuda' in spec else 'no'),
+            '--enable-af_ocl={0}'.format('yes' if 'arrayfire=ocl' in spec else 'no')
+        ])
+
+        # Construct list of optional modules
+
+        # If we have specified any optional modules then add the argument to
+        # enable or disable them.
+        optional_modules = self.spec.variants['optional_modules'].value
+        if optional_modules:
+            # From 'configure --help' @2.3:
+            # all/none/reset or : separated list such as
+            # +crystallization:-bias default: reset
+            configure_opts.append(
+                '--enable-modules={0}'.format(optional_modules)
+            )
+
+        return configure_opts


### PR DESCRIPTION
Gromacs was the only software that needed a recipe modification in order to work. I have basically told spack it is ok to patch gromacs@2021.4 with plumed 2.7.2 even though that specific version is not listed as supported.