### PR TITLE
Marco/setonix packages defaults

### DIFF
--- a/setonix/configs_site_allusers/packages.yaml
+++ b/setonix/configs_site_allusers/packages.yaml
@@ -302,28 +302,29 @@ packages:
 #    - spec: binutils@2.35.1
 #      prefix: /usr
 #    buildable: false
-#  hwloc:
-#    externals:
-#    - spec: hwloc@2.0.0
-#      prefix: /usr
-#    buildable: false
-#  libxml2:
-#    externals:
-#    - spec: libxml2@2.9.7
-#      prefix: /usr
-#    buildable: false
-#  libpciaccess:
-#    externals:
-#    - spec: libpciaccess@0.14
-#      prefix: /usr
-#    buildable: false
-#  ncurses:
-#    externals:
-#    - spec: ncurses@6.1
-#      prefix: /usr
+  hwloc:
+    externals:
+    - spec: hwloc@2.0.0
+      prefix: /usr
+    buildable: false
+  libxml2:
+    externals:
+    - spec: libxml2@2.9.7
+      prefix: /usr
+    buildable: false
+  libpciaccess:
+    externals:
+    - spec: libpciaccess@0.14
+      prefix: /usr
+    buildable: false
+  ncurses:
+    externals:
+    - spec: ncurses@6.1
+      prefix: /usr
+# this one still has no devel
 #    - spec: ncurses@5.9
 #      prefix: /usr
-#    buildable: false
+    buildable: false
 #  numactl:
 #    externals:
 #    - spec: numactl@2.0.11
@@ -339,7 +340,6 @@ packages:
     externals:
     - spec: libfuse@2.9.7
       prefix: /usr
-  # current system installation misses binaries (and headers), hence buildable for now
     buildable: false
   lz4:
     externals:

--- a/setonix/configs_site_allusers/packages.yaml
+++ b/setonix/configs_site_allusers/packages.yaml
@@ -15,8 +15,146 @@ packages:
       read: world
       write: group
       group: pawsey0001
+
+  # GENERAL NOTES:
+  # 1. for each package, only one entry must exist in this yaml
+  # otherwise only the last one is considered, and the previous ones are ingored
+  # 2. when externals are specified, the preferred version is respected only if it is one of the externals
+
+  # preferred versions (for 2022.01) and variants, utils
   cmake:
     version: [3.21.4]
+    externals:
+  # manual addition with the latest version
+# TODO : set final path for cmake on Setonix
+    - spec: cmake@3.21.4
+      prefix: /lus/joey/home/mdelapierre/Spack-sprints/v0.17.0_new/spack/opt/spack/cray-sles15-zen2/gcc-10.3.0/cmake-3.21.4-dgyicf6mmctyfw2fdzeja2jt5jf5gzl5
+    - spec: cmake@3.10.2
+      prefix: /usr
+  # in the future, maybe spack install a couple of recent versions, and make not buildable
+    buildable: false
+  ffmpeg:
+    version: [4.4]
+    variants: '+avresample'
+  gnuplot:
+    version: [5.4.1]
+    variants: '+X'
+  # preferred versions (for 2022.01) and variants, python
+  python:
+    version: [3.9.7]
+    variants: '+optimizations'
+    externals:
+# TODO : either add python@3.9.7+optimizations by Spack as external, 
+#        or comment out the other externals.
+#        Otherwise, the preferred version is ignored
+    - spec: python@3.9.7+optimizations
+      prefix: /lus/joey/home/mdelapierre/Spack-sprints/v0.17.0_new/spack/opt/spack/cray-sles15-zen2/gcc-10.3.0/python-3.9.7-2nk3ozgzzug2migecarn5ez4ppjov2oe
+    - spec: python@3.8.5
+      prefix: /opt/cray/pe/python/3.8.5.1
+    - spec: python@3.6.12
+      prefix: /usr
+    - spec: python@2.7.17
+      prefix: /usr
+    buildable: true
+  py-cython:
+    version: [0.29.24]
+  py-dask:
+    version: [2021.6.2]
+  py-h5py:
+    version: [3.4.0]
+  py-ipython:
+    version: [7.28.0]
+  py-matplotlib:
+    version: [3.4.3]
+    variants: '+movies'
+  py-mpi4py:
+    version: [3.1.2]
+  py-numba:
+    version: [0.54.0]
+  py-numpy:
+    version: [1.20.3]
+  py-pandas:
+    version: [1.3.4]
+  py-pip:
+    version: [21.1.2]
+  py-plotly:
+    version: [5.2.2]
+  py-scikit-learn:
+    version: [1.0.1]
+  py-scipy:
+    version: [1.7.1]
+  py-setuptools:
+    version: [57.4.0]
+  # preferred versions (for 2022.01) and variants, compilers
+  go:
+    version: [1.16.4]
+  julia:
+     version: [1.6.1]
+  openjdk:
+    version: [17.0.0_35]
+  r:
+    version: [4.1.0]
+    externals:
+# TODO : either add r@4.1.0 by Spack as external, 
+#        or comment out the other externals.
+#        Otherwise, the preferred version is ignored
+    - spec: r@4.0.5.1
+      prefix: /opt/cray/pe/R/4.0.5.1
+    buildable: true
+  perl:
+    version: [5.34.0]
+# TODO : either add perl@5.34.0 by Spack as external, 
+#        or comment out the other externals.
+#        Otherwise, the preferred version is ignored
+# system version is old, perhaps we can comment out
+#    externals:
+#    - spec: perl@5.26.1~cpanm
+#      prefix: /usr
+    buildable: true
+  ruby:
+    version: [3.0.1]
+  rust:
+    version: [1.52.1]
+  # preferred versions (for 2022.01) and variants, num_libs
+  boost:
+    version: [1.76.0]
+    variants: '+mpi +numpy +python'
+  eigen:
+    version: [3.4]
+  fftw:
+  # need to add variant 'precision=float,double,long_double', here and in the num_libs environment
+    version: [3.3.9,2.1.5]
+    variants: '+openmp'
+  gsl:
+    version: [2.6]
+  hpx:
+    version: [1.6.0]
+    variants: '+async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi'
+  kokkos:
+    version: [3.4.01]
+    variants: '+hwloc +memkind +numactl +openmp +tuning'
+  netlib-lapack:
+    version: [3.9.1]
+  openblas:
+    version: [0.3.15]
+    variants: 'threads=openmp'
+  opencv:
+     version: [4.5.2]
+  plasma:
+    version: [20.9.20]
+  petsc:
+    version: [3.15]
+    variants: '+fftw +trilinos'
+  plumed:
+    version: [2.7.2]
+  netlib-scalapack:
+    version: [@2.1.0]
+  slate:
+    version: [2021.05.02]
+    variants: 'cuda=off's
+  trilinos:
+    version: [13.0.1]
+    variants: '+adios2 +openmp +python'
 
 # don't build virtuals with an external provider
   mpi:
@@ -54,16 +192,6 @@ packages:
 #    - spec: bzip2@1.0.6
 #      prefix: /usr
 #    buildable: false
-  cmake:
-    externals:
-  # manual addition with the latest version
-# TODO : set final path for cmake on Setonix
-#    - spec: cmake@3.21.4
-#      prefix: /lus/joey/home/mdelapierre/spack/opt/spack/cray-sles15-zen2/gcc-10.3.0/cmake-3.21.3-ws6puo53ecnvukfyps2beb23dgv4imsg
-    - spec: cmake@3.10.2
-      prefix: /usr
-  # in the future, maybe spack install a couple of recent versions, and make not buildable
-    buildable: false
   cpio:
     externals:
     - spec: cpio@2.12
@@ -134,28 +262,11 @@ packages:
     - spec: openssl@1.1.0i-fips
       prefix: /usr
     buildable: false
-  perl:
-    externals:
-    - spec: perl@5.26.1~cpanm
-      prefix: /usr
-    buildable: true
   pkg-config:
     externals:
     - spec: pkg-config@0.29.2
       prefix: /usr
     buildable: false
-  python:
-    externals:
-    - spec: python@2.7.17
-#    - spec: python@2.7.17+bz2+ctypes~dbm~lzma+nis+pyexpat+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-      prefix: /usr
-    - spec: python@3.6.12
-#    - spec: python@3.6.12+bz2+ctypes~dbm+lzma+nis+pyexpat+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-      prefix: /usr
-    - spec: python@3.8.5
-#    - spec: python@3.8.5+bz2+ctypes+dbm+lzma+nis+pyexpat+readline+sqlite3+ssl~tix~tkinter+uuid+zlib
-      prefix: /opt/cray/pe/python/3.8.5.1
-    buildable: true
   rsync:
     externals:
     - spec: rsync@3.1.3
@@ -340,11 +451,6 @@ packages:
       - papi/6.0.0.7
       prefix: /opt/cray/pe/papi/6.0.0.7
     buildable: false
-  r:
-    externals:
-    - spec: r@4.0.5.1
-      prefix: /opt/cray/pe/R/4.0.5.1
-    buildable: true
 
 # cray hdf5
 # cray parallel-netcdf


### PR DESCRIPTION
Hi @pelahi ,
as promised, here are my updates to packages.yaml:

1. added preferred variants/versions for stuff that might be a dependency, i.e. utils, num_libs, python pkgs, compilers
2. decommented some externals, in light of new devel rpms by Sumitha/Kevin

Notes: 
1. I have not added versions/variants for the IO libaries yet, I figured out you know better which should be the default ones, if any
2. I have learnt a couple of behaviours in the yaml, that may cause issues:
    A. there must be only one entry for each package, otherwise only the last one is considered. I learnt that because I was specifying a first `python:` entry just for versions/variants, and then there was another one with the list of externals.... nope, had to consolidate all `python:` properties into one entry in the yaml.
    B. if a package also has externals listed, the versions/variants are honoured only if they are one of the externals, and ignored otherwise. For instance, to have `python@3.9.7+optimizations` as the default, we either add it to the list of externals, or get rid of all python externals (system 2/3, cray-python) all together. I think we have this decision to make only for python, r, perl. I would be tempted to use add the external for python and r, but not for perl (the system perl is quite old any way, and not super-critical to our deployment).

I hope this PR can be useful ahead of the test of the full stack build.

Please have a look, and feel free to proceed with edits/approval as you think best.
