### PR TITLE
openfoam@2012

### DIFF
--- a/setonix/configs_site_allusers/packages.yaml
+++ b/setonix/configs_site_allusers/packages.yaml
@@ -297,11 +297,13 @@ packages:
     - spec: tar@1.30
       prefix: /usr
     buildable: false
+#AEG: modification for OpenFOAM@2012 to work (texinfo->mpfr->cgal->openfoam)
   texinfo:
-    externals:
-    - spec: texinfo@6.5
-      prefix: /usr
-    buildable: false
+##    externals:
+##    - spec: texinfo@6.5
+##      prefix: /usr
+##    buildable: false
+    buildable: true
   xz:
     externals:
     - spec: xz@5.2.3

--- a/setonix/environments/env_apps/spack.yaml
+++ b/setonix/environments/env_apps/spack.yaml
@@ -24,7 +24,9 @@ spack:
       backend=mpi
     - nektar@5.0.2
     - nwchem@7.0.2
-    - openfoam@v2012 +paraview +vtk
+# Failing:    - openfoam@v2012 +paraview +vtk #paraview is failing to be installed, then breaking this spec.
+# Current alternative:
+    - openfoam@v2012
 # Failing:    - openfoam-org@8 #Alexis still working on it
     - quantum-espresso@6.8 +epw +openmp hdf5=parallel
     - vasp@5.4.4 +scalapack +vaspsol

--- a/setonix/repo_setonix/packages/openfoam/1612-spack-patches.patch
+++ b/setonix/repo_setonix/packages/openfoam/1612-spack-patches.patch
@@ -1,0 +1,876 @@
+#############################################################################
+# This patch for OpenFOAM-1612 comprises the following changes:
+#
+# bin/foamEtcFile
+# - Adjust to cope with spack naming (eg, openfoam-com-1612-abcxzy).
+#   Lets us avoid a needless directory layer.
+#
+# etc/bashrc
+# - improved robustness when sourcing.
+# - source top-level prefs.sh first (for sysadmin changes)
+#
+# etc/config.*/settings
+# - write job control information to the user directory
+# - site/ directory under the OpenFOAM project dir, not its parent dir
+#
+# etc/config.*/mpi
+# - added USERMPI as place for spack mpi information
+#
+# mgridgen, zoltan:
+# - make location configurable
+#
+# metis, scotch:
+# - also check lib path (not just lib64)
+#
+# All issues patched here are addressed in OpenFOAM-1706 and later.
+#
+# <Mark.Olesen@esi-group.com>   ESI-OpenCFD   www.openfoam.com
+#
+#############################################################################
+--- OpenFOAM-v1612+.orig/bin/foamEtcFile	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-plus/bin/foamEtcFile	2017-12-18 17:48:35.043291205 +0100
+@@ -4,164 +4,235 @@
+ # \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+ #  \\    /   O peration     |
+ #   \\  /    A nd           | Copyright (C) 2011-2016 OpenFOAM Foundation
+-#    \\/     M anipulation  |
++#    \\/     M anipulation  | Copyright (C) 2017 OpenCFD Ltd.
+ #-------------------------------------------------------------------------------
+ # License
+-#     This file is part of OpenFOAM.
+-#
+-#     OpenFOAM is free software: you can redistribute it and/or modify it
+-#     under the terms of the GNU General Public License as published by
+-#     the Free Software Foundation, either version 3 of the License, or
+-#     (at your option) any later version.
+-#
+-#     OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+-#     ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+-#     FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+-#     for more details.
+-#
+-#     You should have received a copy of the GNU General Public License
+-#     along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
++#     This file is part of OpenFOAM, licensed under GNU General Public License
++#     <http://www.gnu.org/licenses/>.
+ #
+ # Script
+ #     foamEtcFile
+ #
+ # Description
+-#     Locate user/group/shipped file with semantics similar to the
+-#     ~OpenFOAM/fileName expansion.
++#     Locate user/group/other file as per '#includeEtc'.
++#
++#     The -mode option can be used to allow chaining from personal settings
++#     to site-wide settings.
+ #
+-#     The -mode option can be used to allow chaining from
+-#     personal settings to site-wide settings.
++#     For example, within the user ~/.OpenFOAM/<VER>/config.sh/compiler:
++#     \code
++#        eval $(foamEtcFile -sh -mode=go config.sh/compiler)
++#     \endcode
+ #
+-#     For example, within the user ~/.OpenFOAM/<VER>/prefs.sh:
++#     The -mode option is similarly used within etc/{bashrc,cshrc} to ensure
++#     that system prefs are respected:
+ #     \code
+-#        foamPrefs=`$WM_PROJECT_DIR/bin/foamEtcFile -m go prefs.sh` \
+-#            && _foamSource $foamPrefs
++#        eval $(foamEtcFile -sh -mode=o  prefs.sh)
++#        eval $(foamEtcFile -sh -mode=ug prefs.sh)
+ #     \endcode
+ #
++# Environment
++#     - WM_PROJECT:         (unset defaults to OpenFOAM)
++#     - WM_PROJECT_SITE:    (unset defaults to PREFIX/site)
++#     - WM_PROJECT_VERSION: (unset defaults to detect from path)
++#
+ # Note
+-#     This script must exist in $FOAM_INST_DIR/OpenFOAM-<VERSION>/bin/
+-#     or $FOAM_INST_DIR/openfoam<VERSION>/bin/ (for the debian version)
++#     This script must exist in one of these locations:
++#     - $WM_PROJECT_INST_DIR/OpenFOAM-<VERSION>/bin
++#     - $WM_PROJECT_INST_DIR/openfoam-<VERSION>/bin
++#     - $WM_PROJECT_INST_DIR/openfoam<VERSION>/bin  (debian version)
+ #
+ #-------------------------------------------------------------------------------
+-usage() {
+-    [ "${optQuiet:-$optSilent}" = true ] && exit 1
+-
+-    exec 1>&2
+-    while [ "$#" -ge 1 ]; do echo "$1"; shift; done
++printHelp() {
+     cat<<USAGE
+ 
+-Usage: ${0##*/} [OPTION] fileName
+-       ${0##*/} [OPTION] -list
++Usage: foamEtcFile [OPTION] fileName
++       foamEtcFile [OPTION] [-list|-list-test] [fileName]
++
+ options:
+-  -all              return all files (otherwise stop after the first match)
+-  -list             list the directories to be searched
+-  -mode <mode>      any combination of u(user), g(group), o(other)
+-  -prefix <dir>     specify an alternative installation prefix
+-  -quiet            suppress all normal output
+-  -silent           suppress all stderr output
+-  -version <ver>    specify an alternative OpenFOAM version
+-                    in the form Maj.Min.Rev (eg, 1.7.0)
+-  -help             print the usage
+-
+-  Locate user/group/shipped file with semantics similar to the
+-  ~OpenFOAM/fileName expansion.
+-
+-  The options can also be specified as a single character
+-  (eg, '-q' instead of '-quiet'), but must not be grouped.
+-
+-  Exit status
+-      0  when the file is found. Print resolved path to stdout.
+-      1  for miscellaneous errors.
+-      2  when the file is not found.
++  -all (-a)         Return all files (otherwise stop after the first match)
++  -list (-l)        List directories or files to be checked
++  -list-test        List (existing) directories or files to be checked
++  -mode=MODE        Any combination of u(user), g(group), o(other)
++  -prefix=DIR       Specify an alternative installation prefix
++  -version=VER      Specify alternative OpenFOAM version (eg, 3.0, 1612, ...)
++  -csh              Produce output suitable for a csh or sh 'eval'
++  -csh-verbose      As per -csh with additional verbosity
++  -sh               Produce output suitable for a csh or sh 'eval'
++  -sh-verbose       As per -sh  with additional verbosity
++  -quiet (-q)       Suppress all normal output
++  -silent (-s)      Suppress stderr, except -csh-verbose, -sh-verbose output
++  -help             Print the usage
++
++Locate user/group/other file as per '#includeEtc'
++
++Do not group single character options.
++Equivalent options:
++  |  -mode=MODE     |  -mode MODE     | -m MODE
++  |  -prefix=DIR    |  -prefix DIR    | -p DIR
++  |  -version=VER   |  -version VER   | -v VER
++
++Exit status
++    0  when the file is found. Print resolved path to stdout.
++    1  for miscellaneous errors.
++    2  when the file is not found.
+ 
+ USAGE
+-    exit 1
++    exit 0  # A clean exit
+ }
+ 
+-#-------------------------------------------------------------------------------
+ 
+-# the bin dir:
+-binDir="${0%/*}"
++unset optQuiet optSilent
++# Report error and exit
++die()
++{
++    [ "${optQuiet:-$optSilent}" = true ] && exit 1
++    exec 1>&2
++    echo
++    echo "Error encountered:"
++    while [ "$#" -ge 1 ]; do echo "    $1"; shift; done
++    echo
++    echo "See 'foamEtcFile -help' for usage"
++    echo
++    exit 1
++}
+ 
+-# the project dir:
+-projectDir="${binDir%/bin}"
++#-------------------------------------------------------------------------------
++binDir="${0%/*}"                # The bin dir
++projectDir="${binDir%/bin}"     # The project dir
++prefixDir="${projectDir%/*}"    # The prefix dir (same as $WM_PROJECT_INST_DIR)
+ 
+-# the prefix dir (same as $FOAM_INST_DIR):
+-prefixDir="${projectDir%/*}"
++# Could not resolve projectDir, prefixDir? (eg, called as ./bin/foamEtcFile)
++if [ "$prefixDir" = "$projectDir" ]
++then
++    binDir="$(cd $binDir && pwd -L)"
++    projectDir="${binDir%/bin}"
++    prefixDir="${projectDir%/*}"
++fi
++projectDirName="${projectDir##*/}"      # The project directory name
+ 
+-# the name used for the project directory
+-projectDirName="${projectDir##*/}"
++projectVersion="$WM_PROJECT_VERSION"    # Empty? - will be treated later
++userDir="$HOME/.OpenFOAM"               # Hard-coded as per foamVersion.H
+ 
+-# version number used for debian packaging
+-unset versionNum
++#-------------------------------------------------------------------------------
+ 
++# Guess project version or simply get the stem part of the projectDirName.
++# Handle standard and debian naming conventions.
+ #
+-# handle standard and debian naming convention
++# - projectVersion: update unless already set
+ #
+-case "$projectDirName" in
+-OpenFOAM-*)         # standard naming convention OpenFOAM-<VERSION>
+-    version="${projectDirName##OpenFOAM-}"
+-    ;;
++# Helper variables:
++# - dirBase (for reassembling name) == projectDirName without the version
++# - versionNum (debian packaging)
++unset dirBase versionNum
++guessVersion()
++{
++    local version
++
++    case "$projectDirName" in
++    (OpenFOAM-* | openfoam-*)
++        # Standard naming: OpenFOAM-<VERSION> or openfoam-<VERSION>
++        dirBase="${projectDirName%%-*}-"
++        version="${projectDirName#*-}"
++        version="${version%%*-}" # Extra safety, eg openfoam-version-packager
++        ;;
++
++    (openfoam[0-9]*)
++        # Debian naming: openfoam<VERSION>
++        dirBase="openfoam"
++        version="${projectDirName#openfoam}"
++        versionNum="$version"
++
++        # Convert digits version number to decimal delineated
++        case "${#versionNum}" in (2|3|4)
++            version=$(echo "$versionNum" | sed -e 's@\([0-9]\)@\1.@g')
++            version="${version%.}"
++            ;;
++        esac
+ 
+-openfoam[0-9]* | openfoam-dev)     # debian naming convention 'openfoam<VERSION>'
+-    versionNum="${projectDirName##openfoam}"
+-    case "$versionNum" in
+-    ??)         # convert 2 digit version number to decimal delineated
+-        version=$(echo "$versionNum" | sed -e 's@\(.\)\(.\)@\1.\2@')
+-        ;;
+-    ???)        # convert 3 digit version number to decimal delineated
+-        version=$(echo "$versionNum" | sed -e 's@\(.\)\(.\)\(.\)@\1.\2.\3@')
++        # Ignore special treatment if no decimals were inserted.
++        [ "${#version}" -gt "${#versionNum}" ] || unset versionNum
+         ;;
+-    ????)       # convert 4 digit version number to decimal delineated
+-        version=$(echo "$versionNum" | sed -e 's@\(.\)\(.\)\(.\)\(.\)@\1.\2.\3.\4@')
+-        ;;
+-    *)          # failback - use current environment setting
+-        version="$WM_PROJECT_VERSION"
++
++    (*)
++        die "unknown/unsupported naming convention for '$projectDirName'"
+         ;;
+     esac
+-    ;;
+ 
+-*)
+-    echo "Error : unknown/unsupported naming convention"
+-    exit 1
+-    ;;
+-esac
++    # Set projectVersion if required
++    : ${projectVersion:=$version}
++}
+ 
+ 
+-# default mode is 'ugo'
+-mode=ugo
+-unset optAll optList optQuiet optSilent
++# Set projectVersion and update versionNum, projectDirName accordingly
++setVersion()
++{
++    projectVersion="$1"
+ 
+-# parse options
++    # Need dirBase when reassembling projectDirName
++    [ -n "$dirBase" ] || guessVersion
++
++    # Debian: update x.y.z -> xyz version
++    if [ -n "$versionNum" ]
++    then
++        versionNum=$(echo "$projectVersion" | sed -e 's@\.@@g')
++    fi
++
++    projectDirName="$dirBase${versionNum:-$projectVersion}"
++}
++
++
++optMode=ugo         # Default mode is always 'ugo'
++unset optAll optList optShell optVersion
++
++# Parse options
+ while [ "$#" -gt 0 ]
+ do
+     case "$1" in
+-    -h | -help)
+-        usage
++    -h | -help*)
++        printHelp
+         ;;
+     -a | -all)
+         optAll=true
++        unset optShell
+         ;;
+     -l | -list)
+         optList=true
++        unset optShell
++        ;;
++    -list-test)
++        optList='test'
++        unset optShell
++        ;;
++    -csh | -sh | -csh-verbose | -sh-verbose)
++        optShell="${1#-}"
++        unset optAll
++        ;;
++    -mode=[ugo]*)
++        optMode="${1#*=}"
++        ;;
++    -prefix=/*)
++        prefixDir="${1#*=}"
++        prefixDir="${prefixDir%/}"
++        ;;
++    -version=*)
++        optVersion="${1#*=}"
+         ;;
+     -m | -mode)
+-        [ "$#" -ge 2 ] || usage "'$1' option requires an argument"
+-        mode="$2"
+-
+-        # sanity check:
+-        case "$mode" in
+-        *u* | *g* | *o* )
+-           ;;
+-        *)
+-           usage "'$1' option with invalid mode '$mode'"
+-           ;;
+-        esac
++        optMode="$2"
+         shift
++        # Sanity check. Handles missing argument too.
++        case "$optMode" in
++        ([ugo]*)
++            ;;
++        (*)
++            die "invalid mode '$optMode'"
++            ;;
++        esac
+         ;;
+     -p | -prefix)
+-        [ "$#" -ge 2 ] || usage "'$1' option requires an argument"
+-        prefixDir="$2"
++        [ "$#" -ge 2 ] || die "'$1' option requires an argument"
++        prefixDir="${2%/}"
+         shift
+         ;;
+     -q | -quiet)
+@@ -171,13 +242,8 @@
+         optSilent=true
+         ;;
+     -v | -version)
+-        [ "$#" -ge 2 ] || usage "'$1' option requires an argument"
+-        version="$2"
+-        # convert x.y.z -> xyz version (if installation looked like debian)
+-        if [ -n "$versionNum" ]
+-        then
+-            versionNum=$(echo "$version" | sed -e 's@\.@@g')
+-        fi
++        [ "$#" -ge 2 ] || die "'$1' option requires an argument"
++        optVersion="$2"
+         shift
+         ;;
+     --)
+@@ -185,7 +251,7 @@
+         break
+         ;;
+     -*)
+-        usage "unknown option: '$*'"
++        die "unknown option: '$1'"
+         ;;
+     *)
+         break
+@@ -195,11 +261,28 @@
+ done
+ 
+ 
+-# debugging:
+-# echo "Installed locations:"
+-# for i in projectDir prefixDir projectDirName version versionNum
++#-------------------------------------------------------------------------------
++
++if [ -n "$optVersion" ]
++then
++    setVersion $optVersion
++elif [ -z "$projectVersion" ]
++then
++    guessVersion
++fi
++
++# Updates:
++# - projectDir  for changes via -prefix or -version
++# - groupDir    for changes via -prefix
++projectDir="$prefixDir/$projectDirName"
++groupDir="${WM_PROJECT_SITE:-$prefixDir/site}"
++
++
++# Debugging:
++# echo "Installed locations:" 1>&2
++# for i in projectDir prefixDir projectDirName projectVersion
+ # do
+-#     eval echo "$i=\$$i"
++#     eval echo "$i=\$$i" 1>&2
+ # done
+ 
+ 
+@@ -210,30 +293,18 @@
+ 
+ # Define the various places to be searched:
+ unset dirList
+-case "$mode" in
+-*u*)  # user
+-    userDir="$HOME/.${WM_PROJECT:-OpenFOAM}"
+-    dirList="$dirList $userDir/$version $userDir"
++case "$optMode" in (*u*) # (U)ser
++    dirList="$dirList $userDir/$projectVersion $userDir"
+     ;;
+ esac
+ 
+-case "$mode" in
+-*g*)  # group (site)
+-    siteDir="${WM_PROJECT_SITE:-$prefixDir/site}"
+-    dirList="$dirList $siteDir/$version $siteDir"
++case "$optMode" in (*g*) # (G)roup == site
++    dirList="$dirList $groupDir/$projectVersion $groupDir"
+     ;;
+ esac
+ 
+-case "$mode" in
+-*o*)  # other (shipped)
+-    if [ -n "$versionNum" ]
+-    then
+-        # debian packaging
+-        dirList="$dirList $prefixDir/openfoam$versionNum/etc"
+-    else
+-        # standard packaging
+-        dirList="$dirList $prefixDir/${WM_PROJECT:-OpenFOAM}-$version/etc"
+-    fi
++case "$optMode" in (*o*) # (O)ther == shipped
++    dirList="$dirList $projectDir/etc"
+     ;;
+ esac
+ set -- $dirList
+@@ -244,50 +315,87 @@
+ #
+ 
+ exitCode=0
+-if [ "$optList" = true ]
++if [ -n "$optList" ]
+ then
+ 
+-    # list directories, or potential file locations
+-    [ "$nArgs" -le 1 ] || usage
++    # List directories, or potential file locations
++    [ "$nArgs" -le 1 ] || \
++    die "-list expects 0 or 1 filename, but $nArgs provided"
+ 
+-    # a silly combination, but -quiet does have precedence
+-    [ "$optQuiet" = true ] && exit 0
++    # A silly combination, but -quiet does have precedence
++    [ -n "$optQuiet" ] && exit 0
++
++    # Test for directory or file too?
++    if [ "$optList" = "test" ]
++    then
++        exitCode=2  # Fallback to a general error (file not found)
+ 
+-    for dir
+-    do
+         if [ "$nArgs" -eq 1 ]
+         then
+-            echo "$dir/$fileName"
++            for dir
++            do
++                resolved="$dir/$fileName"
++                if [ -f "$resolved" ]
++                then
++                    echo "$resolved"
++                    exitCode=0  # OK
++                fi
++            done
+         else
+-            echo "$dir"
++            for dir
++            do
++                if [ -d "$dir" ]
++                then
++                    echo "$dir"
++                    exitCode=0  # OK
++                fi
++            done
+         fi
+-    done
++    else
++        for dir
++        do
++            echo "$dir${fileName:+/}$fileName"
++        done
++    fi
+ 
+ else
+ 
+-    [ "$nArgs" -eq 1 ] || usage
++    [ "$nArgs" -eq 1 ] || die "One filename expected - $nArgs provided"
+ 
+-    # general error, eg file not found
+-    exitCode=2
++    exitCode=2  # Fallback to a general error (file not found)
+ 
+     for dir
+     do
+         if [ -f "$dir/$fileName" ]
+         then
+             exitCode=0
+-            if [ "$optQuiet" = true ]
+-            then
++            [ -n "$optQuiet" ] && break
++
++            case "$optShell" in
++            (*verbose)
++                echo "Using: $dir/$fileName" 1>&2
++                ;;
++            esac
++
++            case "$optShell" in
++            csh*)
++                echo "source $dir/$fileName"
+                 break
+-            else
++                ;;
++            sh*)
++                echo ". $dir/$fileName"
++                break
++                ;;
++            *)
+                 echo "$dir/$fileName"
+-                [ "$optAll" = true ] || break
+-            fi
++                [ -n "$optAll" ] || break
++                ;;
++            esac
+         fi
+     done
+ 
+ fi
+ 
+-
+ exit $exitCode
+ 
+ #------------------------------------------------------------------------------
+--- OpenFOAM-v1612+.orig/etc/bashrc	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/etc/bashrc	2017-03-22 16:05:05.751237072 +0100
+@@ -42,7 +42,8 @@
+ #
+ # Please set to the appropriate path if the default is not correct.
+ #
+-[ $BASH_SOURCE ] && FOAM_INST_DIR=$(\cd ${BASH_SOURCE%/*/*/*} && \pwd -P) || \
++rc="${BASH_SOURCE:-${ZSH_NAME:+$0}}"
++[ -n "$rc" ] && FOAM_INST_DIR=$(\cd $(dirname $rc)/../.. && \pwd -L) || \
+ FOAM_INST_DIR=$HOME/$WM_PROJECT
+ # FOAM_INST_DIR=~$WM_PROJECT
+ # FOAM_INST_DIR=/opt/$WM_PROJECT
+@@ -135,8 +136,10 @@
+ # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ . $WM_PROJECT_DIR/etc/config.sh/functions
+ 
+-# Add in preset user or site preferences:
+-_foamSource `$WM_PROJECT_DIR/bin/foamEtcFile prefs.sh`
++# Override definitions via prefs, with 'other' first so the sys-admin
++# can provide base values independent of WM_PROJECT_SITE
++_foamSource `$WM_PROJECT_DIR/bin/foamEtcFile -mode o  prefs.sh`
++_foamSource `$WM_PROJECT_DIR/bin/foamEtcFile -mode ug prefs.sh`
+ 
+ # Evaluate command-line parameters and record settings for later
+ # these can be used to set/unset values, or specify alternative pref files
+diff -uw OpenFOAM-v1612+.orig/etc/cshrc OpenFOAM-v1612+/etc/cshrc
+--- OpenFOAM-v1612+.orig/etc/cshrc	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/etc/cshrc	2017-03-22 16:04:51.839291067 +0100
+@@ -148,8 +148,10 @@
+ # Source files, possibly with some verbosity
+ alias _foamSource 'if ($?FOAM_VERBOSE && $?prompt) echo "Sourcing: \!*"; if (\!* != "") source \!*'
+ 
+-# Add in preset user or site preferences:
+-_foamSource `$WM_PROJECT_DIR/bin/foamEtcFile prefs.csh`
++# Override definitions via prefs, with 'other' first so the sys-admin
++# can provide base values independent of WM_PROJECT_SITE
++_foamSource `$WM_PROJECT_DIR/bin/foamEtcFile -mode o  prefs.csh`
++_foamSource `$WM_PROJECT_DIR/bin/foamEtcFile -mode ug prefs.csh`
+ 
+ # Evaluate command-line parameters and record settings for later
+ # these can be used to set/unset values, or specify alternative pref files
+--- OpenFOAM-v1612+.orig/etc/config.sh/settings	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/etc/config.sh/settings	2017-12-21 20:40:50.109036445 +0100
+@@ -141,7 +141,7 @@
+ #------------------------------------------------------------------------------
+ 
+ # Location of the jobControl directory
+-export FOAM_JOB_DIR=$WM_PROJECT_INST_DIR/jobControl
++export FOAM_JOB_DIR="$HOME/.OpenFOAM/jobControl"
+ 
+ # wmake configuration
+ export WM_DIR=$WM_PROJECT_DIR/wmake
+@@ -198,8 +198,12 @@
+ unset siteDir
+ 
+ _foamAddPath $FOAM_USER_APPBIN:$FOAM_SITE_APPBIN:$FOAM_APPBIN
+-# Make sure to pick up dummy versions of external libraries last
+-_foamAddLib  $FOAM_USER_LIBBIN:$FOAM_SITE_LIBBIN:$FOAM_LIBBIN:$FOAM_EXT_LIBBIN:$FOAM_LIBBIN/dummy
++_foamAddLib  $FOAM_LIBBIN/dummy     # Dummy versions of external libraries last
++if [ -n "$FOAM_EXT_LIBBIN" ]        # External libraries (allowed to be unset)
++then
++    _foamAddLib $FOAM_EXT_LIBBIN
++fi
++_foamAddLib  $FOAM_USER_LIBBIN:$FOAM_SITE_LIBBIN:$FOAM_LIBBIN
+ 
+ # Compiler settings
+ # ~~~~~~~~~~~~~~~~~
+--- OpenFOAM-v1612+.orig/etc/config.csh/settings	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/etc/config.csh/settings	2017-12-21 20:37:24.301773802 +0100
+@@ -137,7 +137,7 @@
+ #------------------------------------------------------------------------------
+ 
+ # Location of the jobControl directory
+-setenv FOAM_JOB_DIR $WM_PROJECT_INST_DIR/jobControl
++setenv FOAM_JOB_DIR "$HOME/.OpenFOAM/jobControl"
+ 
+ # wmake configuration
+ setenv WM_DIR $WM_PROJECT_DIR/wmake
+@@ -196,8 +196,11 @@
+ unset siteDir
+ 
+ _foamAddPath ${FOAM_USER_APPBIN}:${FOAM_SITE_APPBIN}:${FOAM_APPBIN}
+-# Make sure to pick up dummy versions of external libraries last
+-_foamAddLib  ${FOAM_USER_LIBBIN}:${FOAM_SITE_LIBBIN}:${FOAM_LIBBIN}:${FOAM_EXT_LIBBIN}:${FOAM_LIBBIN}/dummy
++_foamAddLib  $FOAM_LIBBIN/dummy     # Dummy versions of external libraries last
++if ( $?FOAM_EXT_LIBBIN ) then       # External libraries (allowed to be unset)
++    _foamAddLib $FOAM_EXT_LIBBIN
++endif
++_foamAddLib  ${FOAM_USER_LIBBIN}:${FOAM_SITE_LIBBIN}:${FOAM_LIBBIN}
+ 
+ # Compiler settings
+ # ~~~~~~~~~~~~~~~~~
+--- OpenFOAM-v1612+.orig/etc/config.sh/mpi	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/etc/config.sh/mpi	2017-03-29 13:55:57.507980699 +0200
+@@ -75,8 +75,15 @@
+     _foamAddMan     $MPI_ARCH_PATH/share/man
+     ;;
+ 
++USERMPI)
++    # Use an arbitrary, user-specified mpi implementation
++    export FOAM_MPI=mpi-user
++    _foamSource `$WM_PROJECT_DIR/bin/foamEtcFile config.sh/mpi-user`
++    ;;
++
+ SYSTEMMPI)
+     export FOAM_MPI=mpi-system
++    _foamSource `$WM_PROJECT_DIR/bin/foamEtcFile config.sh/mpi-system`
+ 
+     if [ -z "$MPI_ROOT" ]
+     then
+--- OpenFOAM-v1612+.orig/etc/config.csh/mpi	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/etc/config.csh/mpi	2017-03-29 13:56:36.347835938 +0200
+@@ -71,8 +71,15 @@
+     _foamAddMan     $MPI_ARCH_PATH/share/man
+     breaksw
+ 
++case USERMPI:
++    # Use an arbitrary, user-specified mpi implementation
++    setenv FOAM_MPI mpi-user
++    _foamSource `$WM_PROJECT_DIR/bin/foamEtcFile config.csh/mpi-user`
++    breaksw
++
+ case SYSTEMMPI:
+     setenv FOAM_MPI mpi-system
++    _foamSource `$WM_PROJECT_DIR/bin/foamEtcFile config.csh/mpi-system`
+ 
+     if ( ! ($?MPI_ROOT) ) then
+         echo
+--- OpenFOAM-v1612+.orig/src/fvAgglomerationMethods/Allwmake	2017-01-02 09:56:17.578558265 +0100
++++ OpenFOAM-v1612+/src/fvAgglomerationMethods/Allwmake	2017-04-18 18:58:38.236795902 +0200
+@@ -4,9 +4,13 @@
+ # Parse arguments for library compilation
+ . $WM_PROJECT_DIR/wmake/scripts/AllwmakeParseArguments
+ 
+-export ParMGridGen=$WM_THIRD_PARTY_DIR/ParMGridGen-1.0
++unset MGRIDGEN_ARCH_PATH
++if settings=$($WM_PROJECT_DIR/bin/foamEtcFile config.sh/mgridgen)
++then
++    . $settings
++fi
+ 
+-if [ -e "$FOAM_LIBBIN/libMGridGen.so" ]
++if [ -e "$MGRIDGEN_ARCH_PATH/include/mgridgen.h" ]
+ then
+     wmake $targetType MGridGenGamgAgglomeration
+ fi
+--- OpenFOAM-v1612+.orig/src/fvAgglomerationMethods/MGridGenGamgAgglomeration/Make/options	2017-01-02 09:56:17.578558265 +0100
++++ OpenFOAM-v1612+/src/fvAgglomerationMethods/MGridGenGamgAgglomeration/Make/options	2017-04-18 18:59:16.860662811 +0200
+@@ -1,15 +1,9 @@
+-/* Needs ParMGridGen environment variable set. (see Allwmake script) */
+-
+-TYPE_REAL=
+-#if defined(WM_SP)
+-TYPE_REAL=-DTYPE_REAL
+-#endif
+-
+ EXE_INC = \
+     -I$(LIB_SRC)/finiteVolume/lnInclude \
+-    -I$(ParMGridGen)/MGridGen/Lib/lnInclude \
+-    -I$(ParMGridGen)/MGridGen/IMlib/lnInclude \
+-    $(TYPE_REAL)
++    -I$(MGRIDGEN_ARCH_PATH)/include
+ 
+ LIB_LIBS = \
+-    -L$(FOAM_EXT_LIBBIN) -lMGridGen
++    -L$(FOAM_EXT_LIBBIN) \
++    -L$(MGRIDGEN_ARCH_PATH)/lib \
++    -L$(MGRIDGEN_ARCH_PATH)/lib$(WM_COMPILER_LIB_ARCH) \
++    -lmgrid
+--- OpenFOAM-v1612+.orig/src/parallel/decompose/Allwmake	2017-03-21 16:34:44.599021283 +0100
++++ OpenFOAM-v1612+/src/parallel/decompose/Allwmake	2017-03-21 16:28:57.243969660 +0100
+@@ -36,6 +36,7 @@
+ 
+     # Library
+     [ -r $FOAM_EXT_LIBBIN/libmetis.so ] || \
++    [ -r $METIS_ARCH_PATH/lib/libmetis.so ] || \
+     [ -r $METIS_ARCH_PATH/lib$WM_COMPILER_LIB_ARCH/libmetis.so ] || \
+     [ "${METIS_ARCH_PATH##*-}" = system ] || {
+         echo "$warning (missing library)"
+@@ -90,6 +91,7 @@
+ 
+     # Library
+     [ -r $FOAM_EXT_LIBBIN/libscotch.so ] || \
++    [ -r $SCOTCH_ARCH_PATH/lib/libscotch.so ] || \
+     [ -r $SCOTCH_ARCH_PATH/lib$WM_COMPILER_LIB_ARCH/libscotch.so ] || \
+     [ "${SCOTCH_ARCH_PATH##*-}" = system ] || {
+         echo "$warning (missing library)"
+--- OpenFOAM-v1612+.orig/src/parallel/decompose/metisDecomp/Make/options	2017-03-21 16:34:25.383075328 +0100
++++ OpenFOAM-v1612+/src/parallel/decompose/metisDecomp/Make/options	2017-03-21 16:30:15.727758338 +0100
+@@ -8,6 +8,7 @@
+  * to support central, non-thirdparty installations
+  */
+ LIB_LIBS = \
++    -L$(METIS_ARCH_PATH)/lib \
+     -L$(METIS_ARCH_PATH)/lib$(WM_COMPILER_LIB_ARCH) \
+     -L$(FOAM_EXT_LIBBIN) \
+     -lmetis
+--- OpenFOAM-v1612+.orig/src/parallel/decompose/ptscotchDecomp/Make/options	2017-03-21 16:34:34.607049385 +0100
++++ OpenFOAM-v1612+/src/parallel/decompose/ptscotchDecomp/Make/options	2017-03-21 16:30:00.479799399 +0100
+@@ -16,6 +16,7 @@
+  * to support central, non-thirdparty installations
+  */
+ LIB_LIBS = \
++    -L$(SCOTCH_ARCH_PATH)/lib \
+     -L$(SCOTCH_ARCH_PATH)/lib$(WM_COMPILER_LIB_ARCH) \
+     -L$(FOAM_EXT_LIBBIN) \
+     -L$(FOAM_EXT_LIBBIN)/$(FOAM_MPI) \
+--- OpenFOAM-v1612+.orig/src/parallel/decompose/scotchDecomp/Make/options	2017-03-21 16:34:39.159036582 +0100
++++ OpenFOAM-v1612+/src/parallel/decompose/scotchDecomp/Make/options	2017-03-21 16:29:46.719836452 +0100
+@@ -16,6 +16,7 @@
+  * to support central, non-thirdparty installations
+  */
+ LIB_LIBS = \
++    -L$(SCOTCH_ARCH_PATH)/lib \
+     -L$(SCOTCH_ARCH_PATH)/lib$(WM_COMPILER_LIB_ARCH) \
+     -L$(FOAM_EXT_LIBBIN) \
+     -lscotch \
+--- OpenFOAM-v1612+.orig/applications/utilities/mesh/manipulation/renumberMesh/Allwmake	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/applications/utilities/mesh/manipulation/renumberMesh/Allwmake	2017-03-28 11:13:35.222727218 +0200
+@@ -4,20 +4,35 @@
+ # Parse arguments for compilation (at least for error catching)
+ . $WM_PROJECT_DIR/wmake/scripts/AllwmakeParseArguments
+ 
+-export COMPILE_FLAGS=''
+-export LINK_FLAGS=''
++unset COMP_FLAGS LINK_FLAGS
+ 
+ if [ -f "${FOAM_LIBBIN}/libSloanRenumber.so" ]
+ then
+-    echo "Found libSloanRenumber.so  --  enabling Sloan renumbering support."
++    echo "    found libSloanRenumber  --  enabling sloan renumbering support."
+     export LINK_FLAGS="${LINK_FLAGS} -lSloanRenumber"
+ fi
+ 
+-if [ -f "${ZOLTAN_ARCH_PATH}/lib/libzoltan.a" -a -f "${FOAM_LIBBIN}/libzoltanRenumber.so" ]
++if [ -f "${FOAM_LIBBIN}/libzoltanRenumber.so" ]
+ then
+-    echo "Found libzoltanRenumber.so  --  enabling zoltan renumbering support."
+-    export COMPILE_FLAGS="-DFOAM_USE_ZOLTAN"
+-    export LINK_FLAGS="${LINK_FLAGS} -lzoltanRenumber -L${ZOLTAN_ARCH_PATH}/lib -lzoltan"
++    if [ -z "$ZOLTAN_ARCH_PATH" ]
++    then
++        # Optional: get ZOLTAN_ARCH_PATH
++        if settings=$($WM_PROJECT_DIR/bin/foamEtcFile config.sh/zoltan)
++        then
++            . $settings
++        fi
++    fi
++
++    for libdir in lib "lib${WM_COMPILER_LIB_ARCH}"
++    do
++        if [ -f "$ZOLTAN_ARCH_PATH/$libdir/libzoltan.a" ]
++        then
++            echo "    found libzoltanRenumber  --  enabling zoltan renumbering support."
++            export COMP_FLAGS="-DFOAM_USE_ZOLTAN"
++            export LINK_FLAGS="${LINK_FLAGS} -lzoltanRenumber -L$ZOLTAN_ARCH_PATH/$libdir -lzoltan"
++            break
++        fi
++    done
+ fi
+ 
+ wmake $targetType
+--- OpenFOAM-v1612+.orig/src/renumber/Allwmake	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/src/renumber/Allwmake	2017-03-28 11:10:22.195543610 +0200
+@@ -5,14 +5,11 @@
+ targetType=libso
+ . $WM_PROJECT_DIR/wmake/scripts/AllwmakeParseArguments
+ 
+-## Get ZOLTAN_ARCH_PATH
+-#if settings=$($WM_PROJECT_DIR/bin/foamEtcFile config.sh/zoltan)
+-#then
+-#    . $settings
+-#    echo "using ZOLTAN_ARCH_PATH=$ZOLTAN_ARCH_PATH"
+-#else
+-#    echo "Error: no config.sh/zoltan settings"
+-#fi
++# Optional: get ZOLTAN_ARCH_PATH
++if settings=$($WM_PROJECT_DIR/bin/foamEtcFile config.sh/zoltan)
++then
++    . $settings
++fi
+ 
+ wmake $targetType renumberMethods
+ 
+--- OpenFOAM-v1612+.orig/src/renumber/zoltanRenumber/Make/options	2016-12-23 15:22:59.000000000 +0100
++++ OpenFOAM-v1612+/src/renumber/zoltanRenumber/Make/options	2017-03-28 11:50:46.484343848 +0200
+@@ -4,10 +4,13 @@
+ EXE_INC = \
+     /* -DFULLDEBUG -g -O0 */ \
+     $(PFLAGS) $(PINC) \
++    ${c++LESSWARN} \
+     -I$(FOAM_SRC)/renumber/renumberMethods/lnInclude \
+     -I$(ZOLTAN_ARCH_PATH)/include/ \
+     -I$(LIB_SRC)/meshTools/lnInclude
+ 
+ LIB_LIBS = \
+-    /* -L$(ZOLTAN_ARCH_PATH)/lib -lzoltan */ \
++    -L$(ZOLTAN_ARCH_PATH)/lib \
++    -L$(ZOLTAN_ARCH_PATH)/lib$(WM_COMPILER_LIB_ARCH) \
++    -lzoltan \
+     -lmeshTools

--- a/setonix/repo_setonix/packages/openfoam/common/README
+++ b/setonix/repo_setonix/packages/openfoam/common/README
@@ -1,0 +1,1 @@
+Helper tools for packaging applications/libraries dependent on OpenFOAM.

--- a/setonix/repo_setonix/packages/openfoam/common/README-spack
+++ b/setonix/repo_setonix/packages/openfoam/common/README-spack
@@ -1,0 +1,15 @@
+Additional notes for spack
+--------------------------
+
+OpenFOAM largely manages its own PATH and LD_LIBRARY_PATH settings.
+The spack build currently also follows this and only provides
+a minimum modules environment.
+
+The variable FOAM_PROJECT_DIR points to the location of the OpenFOAM project
+and shall contain a $FOAM_PROJECT_DIR/etc/bashrc file for OpenFOAM.
+The variable FOAM_INST_DIR may also be provided for older OpenFOAM versions.
+
+It is the aim for the future to use spack to provide the environment directly,
+but this still needs more work.
+
+2017-04-18

--- a/setonix/repo_setonix/packages/openfoam/common/change-sitedir.sh
+++ b/setonix/repo_setonix/packages/openfoam/common/change-sitedir.sh
@@ -1,0 +1,94 @@
+#----------------------------------*-sh-*--------------------------------------
+# =========                 |
+# \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+#  \\    /   O peration     |
+#   \\  /    A nd           | Copyright (C) 2017 OpenCFD Ltd.
+#    \\/     M anipulation  |
+#------------------------------------------------------------------------------
+# License
+#     This file is part of OpenFOAM.
+#
+#     OpenFOAM is free software: you can redistribute it and/or modify it
+#     under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+#     ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#     FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#     for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Script
+#     . change-sitedir.sh PREFIX [SUFFIX]
+#
+#     Shortcuts (prefix)
+#         -prefix         "$WM_PROJECT_INST_DIR/site"
+#         -project        "$WM_PROJECT_DIR/site"
+#         -none           remove from environment
+#
+#     Shortcuts (suffix)
+#         -platforms      "platforms/$WM_OPTIONS"
+#
+# Description
+#     Change WM_PROJECT_SITE, FOAM_SITE_APPBIN, FOAM_SITE_LIBBIN
+#     and the respective entries in PATH, LD_LIBRARY_PATH.
+#
+#     This can be useful when temporarily reassigning the site directory
+#     when packaging OpenFOAM.
+#
+#     The suffix value should normally include "platforms/$WM_OPTIONS"
+#
+# Example
+#     . /path/change-sitedir.sh -prefix -platforms
+#
+#   corresponds to the standard site location:
+#
+#     $WM_PROJECT_INST_DIR/site{/$WM_PROJECT_VERSION/platforms/$WM_OPTIONS}
+#
+#------------------------------------------------------------------------------
+
+if [ "$#" -ge 1 ]
+then
+    prefix="$1"
+    suffix="$2"
+
+    foamOldDirs="$FOAM_SITE_APPBIN $FOAM_SITE_LIBBIN \
+        $WM_PROJECT_SITE $WM_PROJECT_INST_DIR/site $WM_PROJECT_DIR/site"
+    foamClean=$WM_PROJECT_DIR/bin/foamCleanPath
+    if [ -x "$foamClean" ]
+    then
+        cleaned=$($foamClean "$PATH" "$foamOldDirs") && PATH="$cleaned"
+        cleaned=$($foamClean "$LD_LIBRARY_PATH" "$foamOldDirs") \
+            && LD_LIBRARY_PATH="$cleaned"
+    fi
+
+    case "$suffix" in
+        -plat*) suffix="platforms/$WM_OPTIONS" ;;
+    esac
+    case "$prefix" in
+        -prefix)  prefix="$WM_PROJECT_INST_DIR/site" ;;
+        -project) prefix="$WM_PROJECT_DIR/site" ;;
+        -none)    unset prefix ;;
+    esac
+
+    if [ -n "$prefix" ]
+    then
+        export WM_PROJECT_SITE="$prefix"
+
+        prefix="$prefix/${WM_PROJECT_VERSION:-unknown}${suffix:+/}${suffix}"
+
+        export FOAM_SITE_APPBIN="$prefix/bin"
+        export FOAM_SITE_LIBBIN="$prefix/lib"
+        PATH="$FOAM_SITE_APPBIN:$PATH"
+        LD_LIBRARY_PATH="$FOAM_SITE_LIBBIN:$LD_LIBRARY_PATH"
+    else
+        unset WM_PROJECT_SITE FOAM_SITE_APPBIN FOAM_SITE_LIBBIN
+    fi
+fi
+
+unset foamClean foamOldDirs cleaned prefix suffix
+
+#------------------------------------------------------------------------------

--- a/setonix/repo_setonix/packages/openfoam/common/change-userdir.sh
+++ b/setonix/repo_setonix/packages/openfoam/common/change-userdir.sh
@@ -1,0 +1,94 @@
+#----------------------------------*-sh-*--------------------------------------
+# =========                 |
+# \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+#  \\    /   O peration     |
+#   \\  /    A nd           | Copyright (C) 2017 OpenCFD Ltd.
+#    \\/     M anipulation  |
+#------------------------------------------------------------------------------
+# License
+#     This file is part of OpenFOAM.
+#
+#     OpenFOAM is free software: you can redistribute it and/or modify it
+#     under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+#     ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#     FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#     for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Script
+#     . change-userdir.sh PREFIX [SUFFIX]
+#
+#     Shortcuts (prefix)
+#         -home           "$HOME/OpenFOAM/$USER-$WM_PROJECT_VERSION"
+#         -none           remove from environment
+#
+#     Shortcuts (suffix)
+#         -platforms      "platforms/$WM_OPTIONS"
+#
+# Description
+#     Change WM_PROJECT_USER_DIR, FOAM_USER_APPBIN, FOAM_USER_LIBBIN
+#     and the respective entries in PATH, LD_LIBRARY_PATH.
+#     Also adjusts FOAM_RUN.
+#
+#     This can be useful with compiling additional OpenFOAM programs
+#     (that use FOAM_USER_APPBIN, FOAM_USER_LIBBIN for their build),
+#     to avoid conflicts with the normal user bin/lib files.
+#
+#     The suffix value should normally include "platforms/$WM_OPTIONS"
+#
+# Example
+#     . /path/change-userdir.sh -home -platforms
+#
+#   corresponds to the standard user location:
+#
+#     $HOME/OpenFOAM/$USER-$WM_PROJECT_VERSION/platforms/$WM_OPTIONS
+#
+#------------------------------------------------------------------------------
+
+if [ "$#" -ge 1 ]
+then
+    prefix="$1"
+    suffix="$2"
+
+    foamOldDirs="$FOAM_USER_APPBIN $FOAM_USER_LIBBIN"
+    foamClean=$WM_PROJECT_DIR/bin/foamCleanPath
+    if [ -x "$foamClean" ]
+    then
+        cleaned=$($foamClean "$PATH" "$foamOldDirs") && PATH="$cleaned"
+        cleaned=$($foamClean "$LD_LIBRARY_PATH" "$foamOldDirs") \
+            && LD_LIBRARY_PATH="$cleaned"
+    fi
+
+    case "$suffix" in
+        -plat*) suffix="platforms/$WM_OPTIONS" ;;
+    esac
+    case "$prefix" in
+        -home) prefix="$HOME/OpenFOAM/$USER-${WM_PROJECT_VERSION:-unknown}" ;;
+        -none) unset prefix ;;
+    esac
+
+    if [ -n "$prefix" ]
+    then
+        export WM_PROJECT_USER_DIR="$prefix"
+        export FOAM_RUN="$prefix/run"
+
+        prefix="$prefix${suffix:+/}${suffix}"
+        export FOAM_USER_APPBIN="$prefix/bin"
+        export FOAM_USER_LIBBIN="$prefix/lib"
+
+        PATH="$FOAM_USER_APPBIN:$PATH"
+        LD_LIBRARY_PATH="$FOAM_USER_LIBBIN:$LD_LIBRARY_PATH"
+    else
+        unset WM_PROJECT_USER_DIR FOAM_RUN FOAM_USER_APPBIN FOAM_USER_LIBBIN
+    fi
+fi
+
+unset foamClean foamOldDirs cleaned prefix suffix
+
+#------------------------------------------------------------------------------

--- a/setonix/repo_setonix/packages/openfoam/common/spack-Allwmake
+++ b/setonix/repo_setonix/packages/openfoam/common/spack-Allwmake
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Build wrapper script
+
+# FOAM_INST_DIR is only required by foam-extend
+export FOAM_INST_DIR=$(cd .. && pwd -L)
+
+# Prevent influence of user/site config when building
+export FOAM_CONFIG_MODE="o"
+
+. "$PWD"/etc/bashrc ''                          # No arguments
+mkdir -p "$FOAM_APPBIN" "$FOAM_LIBBIN"          # Allow build interrupt
+
+echo "Build openfoam with SPACK ($@)"
+echo "WM_PROJECT_DIR = $WM_PROJECT_DIR"
+
+# Prefer spack-specific Allwmake if it exists
+if [ -f Allwmake-spack ]
+then
+    ./Allwmake-spack $@   # Pass arguments
+else
+    ./Allwmake $@         # Pass arguments
+    ##echo "Disabled build of openfoam"   # When testing environment only
+
+    # Generate manpages
+    if [ -x bin/tools/foamCreateManpage ]
+    then
+        bin/tools/foamCreateManpage -gzip || \
+            echo "ignore problems generating manpages"
+    fi
+fi
+
+
+# Link non-dummy MPI_FOAM type to parent-dir, where rpath can find it
+if [ "${FOAM_MPI:=dummy}" != dummy ] && [ -d "$FOAM_LIBBIN/$FOAM_MPI" ]
+then
+(
+    cd "$FOAM_LIBBIN" || exit 1
+    for i in "$FOAM_MPI"/lib*.so
+    do
+        [ -f "$i" ] && ln -sf "$i" "${i##*/}"
+    done
+)
+fi
+
+# -----------------------------------------------------------------------------

--- a/setonix/repo_setonix/packages/openfoam/common/spack-derived-Allwmake
+++ b/setonix/repo_setonix/packages/openfoam/common/spack-derived-Allwmake
@@ -1,0 +1,34 @@
+#!/bin/bash
+# The openfoam providers must export 'FOAM_PROJECT_DIR'
+# The derived package is expected to supply an appropriate
+# <Allwmake> or <Allwmake-spack> file.
+
+[ -d "$FOAM_PROJECT_DIR" -a -f "$FOAM_PROJECT_DIR/etc/bashrc" ] || {
+    echo "Error: no PROJECT=$FOAM_PROJECT_DIR" 1>&2
+    echo "    or no etc/bashrc found" 1>&2
+    exit 1
+}
+
+export FOAM_INST_DIR=$(cd $FOAM_PROJECT_DIR/.. && pwd -L) # Needed by foam-extend
+. "$FOAM_PROJECT_DIR"/etc/bashrc ''  # No arguments
+
+# Package-specific adjustments
+[ -f spack-config.sh ] && . ./spack-config.sh ''  # No arguments
+
+echo "========================================"
+date "+%Y-%m-%d %H:%M:%S %z" 2>/dev/null || echo "date is unknown"
+echo "Build with ${WM_PROJECT}-${WM_PROJECT_VERSION}"
+echo "  WM_PROJECT_DIR = $WM_PROJECT_DIR"
+echo "  $WM_COMPILER $WM_COMPILER_TYPE compiler"
+echo "  $WM_OPTIONS - with $WM_MPLIB $FOAM_MPI"
+echo
+
+# Prefer spack-specific Allwmake if it exists
+if [ -f Allwmake-spack ]
+then
+    ./Allwmake-spack $@   # Pass arguments
+else
+    ./Allwmake $@         # Pass arguments
+fi
+
+# -----------------------------------------------------------------------------

--- a/setonix/repo_setonix/packages/openfoam/common/spack-dummy-Allwmake
+++ b/setonix/repo_setonix/packages/openfoam/common/spack-dummy-Allwmake
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Build wrapper script for dummy build
+
+# Prevent influence of user/site config when building
+export FOAM_CONFIG_MODE="o"
+. "$PWD"/etc/bashrc ''                          # No arguments
+
+echo "Dummy build openfoam with SPACK ($@)"
+echo "WM_PROJECT_DIR = $WM_PROJECT_DIR"
+
+if [ -f applications/test/00-dummy/Allwmake ]
+then
+    applications/test/00-dummy/Allwmake $@
+else
+    echo "Nothing to make"
+fi
+
+# -----------------------------------------------------------------------------

--- a/setonix/repo_setonix/packages/openfoam/package.py
+++ b/setonix/repo_setonix/packages/openfoam/package.py
@@ -1,0 +1,1225 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
+# Author: Mark Olesen <mark.olesen@esi-group.com>
+#
+# Legal Notice
+# ------------
+# OPENFOAM is a trademark owned by OpenCFD Ltd
+# (producer and distributor of the OpenFOAM software via www.openfoam.com).
+# The trademark information must remain visible and unadulterated in this
+# file and via the "spack info" and comply with the term set by
+# http://openfoam.com/legal/trademark-policy.php
+#
+# This file is not part of OpenFOAM, nor does it constitute a component of an
+# OpenFOAM distribution.
+#
+##############################################################################
+#
+# Notes
+# - mpi handling: WM_MPLIB=USERMPI and use spack to generate mplibUSERMPI
+#   wmake rules.
+#
+# - Resolution of flex, zlib needs more attention (within OpenFOAM)
+# - +paraview:
+#   depends_on should just be 'paraview+plugins' but that resolves poorly.
+#   Workaround: use preferred variants "+plugins +qt"
+#       packages:
+#           paraview:
+#               variants: +plugins +qt
+#   in ~/.spack/packages.yaml
+#
+# Known issues
+# - Combining +zoltan with +int64 has not been tested, but probably won't work.
+# - Combining +mgridgen with +int64 or +float32 probably won't work.
+#
+# The spack 'develop' version of openfoam retains the upstream
+# WM_PROJECT_VERSION=com naming internally.
+#
+##############################################################################
+import glob
+import os
+import re
+#AEG: Importing this module to use their tools for copying files
+import shutil
+
+import llnl.util.tty as tty
+
+from spack import *
+from spack.util.environment import EnvironmentModifications
+
+#AEG: Will use this function to save the original files before any modification
+def save_original(theFile):
+    backHere = theFile + '.original'
+    if not os.path.isfile(backHere):
+        shutil.copyfile(theFile, backHere)
+
+# Not the nice way of doing things, but is a start for refactoring
+__all__ = [
+    'add_extra_files',
+    'write_environ',
+    'rewrite_environ_files',
+    'mplib_content',
+    'foam_add_path',
+    'foam_add_lib',
+    'OpenfoamArch',
+]
+
+
+def add_extra_files(foam_pkg, common, local, **kwargs):
+    """Copy additional common and local files into the stage.source_path
+    from the openfoam/common and the package/assets directories,
+    respectively
+    """
+    outdir = foam_pkg.stage.source_path
+
+    indir  = join_path(os.path.dirname(__file__), 'common')
+    for f in common:
+        tty.info('Added file {0}'.format(f))
+        install(join_path(indir, f), join_path(outdir, f))
+
+    indir  = join_path(foam_pkg.package_dir, 'assets')
+    for f in local:
+        tty.info('Added file {0}'.format(f))
+        install(join_path(indir, f), join_path(outdir, f))
+
+
+def format_export(key, value):
+    """Format key,value pair as 'export' with newline for POSIX shell.
+    A leading '#' for key adds a comment character to the entire line.
+    A value of 'None' corresponds to 'unset'.
+    """
+    if key.startswith('#'):
+        return '## export {0}={1}\n'.format(re.sub(r'^#+\s*', '', key), value)
+    elif value is None:
+        return 'unset {0}\n'.format(key)
+    else:
+        return 'export {0}={1}\n'.format(key, value)
+
+
+def format_setenv(key, value):
+    """Format key,value pair as 'setenv' with newline for C-shell.
+    A leading '#' for key adds a comment character to the entire line.
+    A value of 'None' corresponds to 'unsetenv'.
+    """
+    if key.startswith('#'):
+        return '## setenv {0} {1}\n'.format(re.sub(r'^#+\s*', '', key), value)
+    elif value is None:
+        return 'unsetenv {0}\n'.format(key)
+    else:
+        return 'setenv {0} {1}\n'.format(key, value)
+
+
+def _write_environ_entries(outfile, environ, formatter):
+    """Write environment settings as 'export' or 'setenv'.
+    If environ is a dict, write in sorted order.
+    If environ is a list, write pair-wise.
+    Also descends into sub-dict and sub-list, but drops the key.
+    """
+    if isinstance(environ, dict):
+        for key in sorted(environ):
+            entry = environ[key]
+            if isinstance(entry, dict):
+                _write_environ_entries(outfile, entry, formatter)
+            elif isinstance(entry, list):
+                _write_environ_entries(outfile, entry, formatter)
+            else:
+                outfile.write(formatter(key, entry))
+    elif isinstance(environ, list):
+        for item in environ:
+            outfile.write(formatter(item[0], item[1]))
+
+
+def _write_environ_file(output, environ, formatter):
+    """Write environment settings as 'export' or 'setenv'.
+    If environ is a dict, write in sorted order.
+    If environ is a list, write pair-wise.
+    Also descends into sub-dict and sub-list, but drops the key.
+    """
+    with open(output, 'w') as outfile:
+        outfile.write('# spack generated\n')
+        _write_environ_entries(outfile, environ, formatter)
+        outfile.write('# spack\n')
+
+
+def write_environ(environ, **kwargs):
+    """Write environment settings as 'export' or 'setenv'.
+    If environ is a dict, write in sorted order.
+    If environ is a list, write pair-wise.
+
+       Keyword Options:
+         posix[=None]    If set, the name of the POSIX file to rewrite.
+         cshell[=None]   If set, the name of the C-shell file to rewrite.
+    """
+    rcfile = kwargs.get('posix', None)
+    if rcfile:
+        _write_environ_file(rcfile, environ, format_export)
+    rcfile = kwargs.get('cshell', None)
+    if rcfile:
+        _write_environ_file(rcfile, environ, format_setenv)
+
+
+def rewrite_environ_files(environ, **kwargs):
+    """Use filter_file to rewrite (existing) POSIX shell or C-shell files.
+       Keyword Options:
+         posix[=None]    If set, the name of the POSIX file to rewrite.
+         cshell[=None]   If set, the name of the C-shell file to rewrite.
+    """
+    rcfile = kwargs.get('posix', None)
+    if rcfile and os.path.isfile(rcfile):
+        for k, v in environ.items():
+            regex = r'^(\s*export\s+{0})=.*$'.format(k)
+            if not v:
+                replace = r'unset {0}  #SPACK: unset'.format(k)
+            elif v.startswith('#'):
+                replace = r'unset {0}  {1}'.format(k, v)
+            else:
+                replace = r'\1={0}'.format(v)
+            #AEG:saving original for easier installation debug
+            save_original(rcfile)
+            filter_file(regex, replace, rcfile, backup=False)
+
+    rcfile = kwargs.get('cshell', None)
+    if rcfile and os.path.isfile(rcfile):
+        for k, v in environ.items():
+            regex = r'^(\s*setenv\s+{0})\s+.*$'.format(k)
+            if not v:
+                replace = r'unsetenv {0}  #SPACK: unset'.format(k)
+            elif v.startswith('#'):
+                replace = r'unsetenv {0}  {1}'.format(k, v)
+            else:
+                replace = r'\1 {0}'.format(v)
+            #AEG:saving original for easier installation debug
+            save_original(rcfile)
+            filter_file(regex, replace, rcfile, backup=False)
+
+
+def foam_add_path(*args):
+    """A string with args prepended to 'PATH'"""
+    return '"' + ':'.join(args) + ':${PATH}"'
+
+
+def foam_add_lib(*args):
+    """A string with args prepended to 'LD_LIBRARY_PATH'"""
+    return '"' + ':'.join(args) + ':${LD_LIBRARY_PATH}"'
+
+
+def pkglib(package, pre=None):
+    """Get lib64 or lib from package prefix.
+
+    Optional parameter 'pre' to provide alternative prefix
+    """
+    libdir = package.prefix.lib64
+    if not os.path.isdir(libdir):
+        libdir = package.prefix.lib
+    if pre:
+        return join_path(pre, os.path.basename(libdir))
+    else:
+        return libdir
+
+
+def mplib_content(spec, pre=None):
+    """The mpi settings (from spack) for the OpenFOAM wmake includes, which
+    allows later reuse within OpenFOAM.
+
+    Optional parameter 'pre' to provide alternative prefix for
+    bin and lib directories.
+    """
+    mpi_spec = spec['mpi']
+    bin = mpi_spec.prefix.bin
+    inc = mpi_spec.headers.directories[0]  # Currently only need first one
+    lib = pkglib(mpi_spec)
+
+    libname = 'mpi'
+    if 'mpich' in mpi_spec.name:
+        libname = 'mpich'
+
+    if pre:
+        bin = join_path(pre, os.path.basename(bin))
+        inc = join_path(pre, os.path.basename(inc))
+        lib = join_path(pre, os.path.basename(lib))
+    else:
+        pre = mpi_spec.prefix
+    info = {
+        'name':   '{0}-{1}'.format(mpi_spec.name, mpi_spec.version),
+        'prefix':  pre,
+        'include': inc,
+        'bindir':  bin,
+        'libdir':  lib,
+        'FLAGS':  '-DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX',
+        'PINC':   '-I{0}'.format(inc),
+        #AEG:'PLIBS':  '-L{0} -l{1}'.format(lib, libname),
+        'PLIBS':  '-L{0} -L{1} -l{2} -l{3}'.format(lib+'$(WM_COMPILER_LIB_ARCH)',lib, libname,'rt'),
+    }
+    return info
+
+
+# -----------------------------------------------------------------------------
+
+class Openfoam(Package):
+    """OpenFOAM is a GPL-opensource C++ CFD-toolbox.
+    This offering is supported by OpenCFD Ltd,
+    producer and distributor of the OpenFOAM software via www.openfoam.com,
+    and owner of the OPENFOAM trademark.
+    OpenCFD Ltd has been developing and releasing OpenFOAM since its debut
+    in 2004.
+    """
+
+    maintainers = ['olesenm']
+    homepage = "https://www.openfoam.com/"
+    url      = "https://sourceforge.net/projects/openfoam/files/v1906/OpenFOAM-v1906.tgz"
+    git      = "https://develop.openfoam.com/Development/openfoam.git"
+    list_url = "https://sourceforge.net/projects/openfoam/files/"
+    list_depth = 2
+
+    version('develop', branch='develop', submodules='True')
+    version('master', branch='master', submodules='True')
+    version('2106', sha256='11e41e5b9a253ef592a8f6b79f6aded623b28308192d02cec1327078523b5a37')
+    version('2012_210414', sha256='5260aaa79f91aad58a3a305c1a12d0d48b10f12e37cd99a6fa561969b15ea09d')
+    version('2012', sha256='3d6e39e39e7ae61d321fbc6db6c3748e6e5e1c4886454207a7f1a7321469e65a')
+    version('2006_201012', sha256='9afb7eee072bfddcf7f3e58420c93463027db2394997ac4c3b87a8b07c707fb0')
+    version('2006', sha256='30c6376d6f403985fc2ab381d364522d1420dd58a42cb270d2ad86f8af227edc')
+    version('1912_200506', sha256='831a39ff56e268e88374d0a3922479fd80260683e141e51980242cc281484121')
+    version('1912_200403', sha256='1de8f4ddd39722b75f6b01ace9f1ba727b53dd999d1cd2b344a8c677ac2db4c0')
+    version('1912', sha256='437feadf075419290aa8bf461673b723a60dc39525b23322850fb58cb48548f2')
+    version('1906_200312', sha256='f75645151ed5d8c5da592d307480979fe580a25627cc0c9718ef370211577594')
+    version('1906_191103', sha256='631a7fcd926ccbcdef0ab737a9dc55e58d6bedae2f3acaa041ea679db6c9303b')
+    version('1906', sha256='bee03c4b1da0d2c9f98eb469eeffbce3a8614728ef8e87f664042a7490976537')
+    version('1812_200312', sha256='925d2877c12740fab177a30fdcaa8899c262c15b90225f9c29d18a2d97532de0')
+    version('1812_191001', sha256='857a3d476696679313ea9a3f022b33446ddef2bcd417049a9486d504c12038dd')
+    version('1812_190531', sha256='51f0ef49a199edf3cd94e2ccfc7330e54e93c8e4ddb29ee66fe3e6b443583b34')
+    version('1812', sha256='d4d23d913419c6a364b1fe91509c1fadb5661bdf2eedb8fe9a8a005924eb2032')
+    version('1806', sha256='6951aab6405294fe59cec90b0a4e425f5403043191cda02ebaaa890ce1fcc819')
+    version('1712', sha256='4d22caa25d638d4c59bb93ee4dec51e8f71724f9f507eeb4162f771ebe885d21')
+    version('1706', sha256='7779048bb53798d9a5bd2b2be0bf302c5fd3dff98e29249d6e0ef7eeb83db79a')
+    version('1612', sha256='2909c43506a68e1f23efd0ca6186a6948ae0fc8fe1e39c78cc23ef0d69f3569d')
+
+    variant('float32', default=False,
+            description='Use single-precision')
+    variant('spdp', default=False,
+            description='Use single/double mixed precision')
+    variant('int64', default=False,
+            description='With 64-bit labels')
+    variant('knl', default=False,
+            description='Use KNL compiler settings')
+    variant('kahip', default=False,
+            description='With kahip decomposition')
+    variant('metis', default=False,
+            description='With metis decomposition')
+    variant('scotch', default=True,
+            description='With scotch/ptscotch decomposition')
+    variant('zoltan', default=False,
+            description='With zoltan renumbering')
+    variant('mgridgen', default=False, description='With mgridgen support')
+    variant('paraview', default=False,
+            description='Build paraview plugins and runtime post-processing')
+    variant('vtk', default=False,
+            description='With VTK runTimePostProcessing')
+    variant('source', default=True,
+            description='Install library/application sources and tutorials')
+
+    depends_on('mpi')
+
+    # After 1712, could suggest openmpi+thread_multiple for collated output
+    # but particular mixes of mpi versions and InfiniBand may not work so well
+    # conflicts('^openmpi~thread_multiple', when='@1712:')
+
+    depends_on('zlib')
+    depends_on('fftw-api')
+    depends_on('boost')
+    # OpenFOAM does not play nice with CGAL 5.X
+    depends_on('cgal@:4')
+    # The flex restriction is ONLY to deal with a spec resolution clash
+    # introduced by the restriction within scotch!
+    depends_on('flex@:2.6.1,2.6.4:')
+    depends_on('cmake', type='build')
+    depends_on('m4', type='build')
+
+    # Require scotch with ptscotch - corresponds to standard OpenFOAM setup
+    depends_on('scotch~metis+mpi~int64', when='+scotch~int64')
+    depends_on('scotch~metis+mpi+int64', when='+scotch+int64')
+    depends_on('kahip',        when='+kahip')
+    depends_on('metis@5:',     when='+metis')
+    depends_on('metis+int64',  when='+metis+int64')
+    # mgridgen is statically linked
+    depends_on('parmgridgen',  when='+mgridgen', type='build')
+    depends_on('zoltan',       when='+zoltan')
+    depends_on('vtk',          when='+vtk')
+    depends_on('adios2',       when='@1912:')
+
+    # For OpenFOAM plugins and run-time post-processing this should just be
+    # 'paraview+plugins' but that resolves poorly.
+    # Workaround: use preferred variants "+plugins +qt" in
+    #   ~/.spack/packages.yaml
+
+    # 1706 ok with newer paraview but avoid pv-5.2, pv-5.3 readers
+    depends_on('paraview@5.4:',   when='@1706:+paraview')
+    # 1612 plugins need older paraview
+    depends_on('paraview@:5.0.1', when='@1612+paraview')
+
+    # General patches
+    common = ['spack-Allwmake', 'README-spack']
+    assets = []
+
+    # Version-specific patches
+    patch('1612-spack-patches.patch', when='@1612')
+    # kahip patch (wmake)
+    patch('https://develop.openfoam.com/Development/openfoam/commit/8831dfc58b0295d0d301a78341dd6f4599073d45.patch',
+          when='@1806',
+          sha256='531146be868dd0cda70c1cf12a22110a38a30fd93b5ada6234be3d6c9256c6cf'
+          )
+
+    # Some user config settings
+    # default: 'compile-option': '-spack',
+    # default: 'mplib': 'USERMPI',  # User-defined mpi for spack
+    config = {
+        # Add links into bin/, lib/ (eg, for other applications)
+        'link':  False
+    }
+
+    # The openfoam architecture, compiler information etc
+    _foam_arch = None
+
+    # Content for etc/prefs.{csh,sh}
+    etc_prefs = {}
+
+    # Content for etc/config.{csh,sh}/ files
+    etc_config = {}
+
+    phases = ['configure', 'build', 'install']
+    build_script = './spack-Allwmake'  # From patch() method.
+
+    #
+    # - End of definitions / setup -
+    #
+
+    def url_for_version(self, version):
+        """Handles locations for patched and unpatched versions.
+        Patched version (eg '1906_191103') are located in the
+        corresponding unpatched directories (eg '1906').
+        Older versions (eg, v1612+) had additional '+' in naming
+        """
+        if version <= Version('1612'):
+            fmt = 'v{0}+/OpenFOAM-v{1}+.tgz'
+        else:
+            fmt = 'v{0}/OpenFOAM-v{1}.tgz'
+        return self.list_url + fmt.format(version.up_to(1), version)
+
+    def setup_minimal_environment(self, env):
+        """Sets a minimal openfoam environment.
+        """
+        tty.info('OpenFOAM minimal env {0}'.format(self.prefix))
+        env.set('FOAM_PROJECT_DIR', self.projectdir)
+        env.set('WM_PROJECT_DIR', self.projectdir)
+        for d in ['wmake', self.archbin]:  # bin added automatically
+            env.prepend_path('PATH', join_path(self.projectdir, d))
+
+    def setup_build_environment(self, env):
+        """Sets the build environment (prior to unpacking the sources).
+        """
+        pass
+
+    def setup_run_environment(self, env):
+        """Sets the run environment (post-installation).
+        The environment comes from running:
+
+        .. code-block:: console
+
+           $ . $WM_PROJECT_DIR/etc/bashrc
+        """
+
+        bashrc = join_path(self.projectdir, 'etc', 'bashrc')
+        minimal = True
+        if os.path.isfile(bashrc):
+            # post-install: source the installed bashrc
+            try:
+                mods = EnvironmentModifications.from_sourcing_file(
+                    bashrc,
+                    clean=True,  # Remove duplicate entries
+                    blacklist=[  # Blacklist these
+                        # Inadvertent changes
+                        # -------------------
+                        'PS1',              # Leave untouched
+                        'MANPATH',          # Leave untouched
+
+                        # Unneeded bits
+                        # -------------
+                        # 'FOAM_SETTINGS',  # Do not use with modules
+                        # 'FOAM_INST_DIR',  # Old
+                        # 'FOAM_(APP|ETC|SRC|SOLVERS|UTILITIES)',
+                        # 'FOAM_TUTORIALS', # May be useful
+                        # 'WM_OSTYPE',      # Purely optional value
+
+                        # Third-party cruft - only used for orig compilation
+                        # -----------------
+                        '[A-Z].*_ARCH_PATH',
+                        # '(KAHIP|METIS|SCOTCH)_VERSION',
+
+                        # User-specific
+                        # -------------
+                        'FOAM_RUN',
+                        '(FOAM|WM)_.*USER_.*',
+                    ],
+                    whitelist=[  # Whitelist these
+                        'MPI_ARCH_PATH',  # Can be required for compilation
+                    ])
+
+                env.extend(mods)
+                minimal = False
+                tty.info('OpenFOAM bashrc env: {0}'.format(bashrc))
+            except Exception:
+                minimal = True
+
+        if minimal:
+            # pre-build or minimal environment
+            self.setup_minimal_environment(env)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        """Use full OpenFOAM environment when building.
+        Mirror WM_PROJECT_DIR value as FOAM_PROJECT_DIR to avoid
+        masking the normal OpenFOAM cleanup of previous versions.
+        """
+        self.setup_run_environment(env)
+        env.set('FOAM_PROJECT_DIR', self.projectdir)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        """Use full OpenFOAM environment when running.
+        Mirror WM_PROJECT_DIR value as FOAM_PROJECT_DIR to avoid
+        masking the normal OpenFOAM cleanup of previous versions.
+        """
+        self.setup_run_environment(env)
+        env.set('FOAM_PROJECT_DIR', self.projectdir)
+
+    @property
+    def projectdir(self):
+        """Absolute location of project directory: WM_PROJECT_DIR/"""
+        return self.prefix  # <- install directly under prefix
+
+    @property
+    def foam_arch(self):
+        if not self._foam_arch:
+            self._foam_arch = OpenfoamArch(self.spec, **self.config)
+        return self._foam_arch
+
+    @property
+    def archbin(self):
+        """Relative location of architecture-specific executables"""
+        return join_path('platforms', self.foam_arch, 'bin')
+
+    @property
+    def archlib(self):
+        """Relative location of architecture-specific libraries"""
+        return join_path('platforms', self.foam_arch, 'lib')
+
+    def patch(self):
+        """Adjust OpenFOAM build for spack.
+           Where needed, apply filter as an alternative to normal patching."""
+        add_extra_files(self, self.common, self.assets)
+
+    @when('@:1806')
+    def patch(self):
+        """Adjust OpenFOAM build for spack.
+           Where needed, apply filter as an alternative to normal patching."""
+        add_extra_files(self, self.common, self.assets)
+
+        # Prior to 1812, required OpenFOAM-v{VER} directory when sourcing
+        projdir = "OpenFOAM-v{0}".format(self.version)
+        if not os.path.exists(join_path(self.stage.path, projdir)):
+            tty.info('Added directory link {0}'.format(projdir))
+            os.symlink(
+                os.path.relpath(
+                    self.stage.source_path,
+                    self.stage.path
+                ),
+                join_path(self.stage.path, projdir)
+            )
+
+        # Avoid WM_PROJECT_INST_DIR for ThirdParty
+        # This modification is non-critical
+        edits = {
+            'WM_THIRD_PARTY_DIR':
+            r'$WM_PROJECT_DIR/ThirdParty  #SPACK: No separate third-party',
+        }
+        rewrite_environ_files(  # etc/{bashrc,cshrc}
+            edits,
+            posix=join_path('etc', 'bashrc'),
+            cshell=join_path('etc', 'cshrc'))
+
+        # The following filtering is non-critical.
+        # It simply prevents 'site' dirs at the wrong level
+        # (likely non-existent anyhow) from being added to
+        # PATH, LD_LIBRARY_PATH.
+        for rcdir in ['config.sh', 'config.csh']:
+            rcfile = join_path('etc', rcdir, 'settings')
+            if os.path.isfile(rcfile):
+                #AEG:saving original for easier installation debug
+                save_original(rcfile)
+                filter_file(
+                    'WM_PROJECT_INST_DIR/',
+                    'WM_PROJECT_DIR/',
+                    rcfile,
+                    backup=False)
+
+    def configure_trapFpe_off(self):
+        """Disable trapFpe handling.
+        Seems to be needed for several clang-derivatives.
+        """
+        # Set 'trapFpe 0' in etc/controlDict
+        controlDict = 'etc/controlDict'
+        if os.path.exists(controlDict):
+            #AEG:saving original for easier installation debug
+            save_original(controlDict)
+            filter_file(r'trapFpe\s+\d+\s*;', 'trapFpe 0;',
+                        controlDict, backup=False)
+
+    #AEG: Using this function to change the default controlDict settings to use collated filehandler
+    def configure_filehandler_collated(self):
+        """Enable filehandler collated by default
+        """
+        # Set 'fileHandler collated' in etc/controlDict
+        controlDict = 'etc/controlDict'
+        if os.path.exists(controlDict):
+            #AEG:saving original for easier installation debug
+            save_original(controlDict)
+            filter_file(r'fileHandler.*;', 'fileHandler collated;',
+                        controlDict, backup=False)
+
+#----
+#AEG: Specific settings for Pawsey
+    def make_pawsey_settings(self):
+        """Settings for Pawsey
+           This for when no @when applies!
+        """
+        tty.info('Nothing to do in this method for Pawsey settings')
+
+    @when('@1812:')
+    def make_pawsey_settings(self):
+        """Settings for Pawsey
+           This for @1812:
+        """
+        tty.info('Calling the collated change:')
+        self.configure_filehandler_collated()
+
+    @run_before('configure')
+    def call_make_pawsey_settings(self):
+        """Finally performing Pawsey Settings
+        """
+        tty.info('Calling the method "pawsey_settings":')
+        self.make_pawsey_settings()
+#-----
+#-----
+    #AEG: This dummy function is when no @when applies:
+    def make_pawsey_rules(self):
+        """Pawsey rules when no @when applies
+        """
+        tty.info('Nothing to do for the Pawsey rules when no @when applies')
+
+    #AEG: The Pawsey Rules rules:
+    @when('@1812: %gcc')
+    def make_pawsey_rules(self):
+        """Create Pawsey rules (based on Cray original rules) unless supplied upstream.
+        """
+        compOrig = 'Cray' #This is the name of existing wmake/rules to be used as template for the new ones
+        compNew = 'CrayGcc' #This is the name to be used for the new wmake/rules
+        compOrigBaseGeneral = 'Gcc' #These are the rules/General used in the original wmake/rules above
+        #compNewBaseGeneral = 'Gcc' #These are the rules/General to be used in the new rules
+
+        general_rules = 'wmake/rules/General'
+        arch_rules = 'wmake/rules/linux64'  # self.arch
+        src = arch_rules + compOrig
+        dst = arch_rules + compNew
+        #AEG: In theory, next line shoudl be used for clang based ones
+        #self.configure_trapFpe_off()  # LLVM may falsely trigger FPE
+
+        if os.path.exists(dst):
+            return
+
+        # Handle rules/<ARCH><COMP> or rules/<ARCH>/<COMP>
+        if not os.path.exists(src):
+            src = join_path(arch_rules, compOrig)
+            dst = join_path(arch_rules, compNew)
+            if os.path.exists(dst):
+                return
+
+        tty.info('Add Pawsey wmake rules')
+        copy_tree(src, dst)
+
+        if self.spec.version >= Version('1906'):
+            for cfg in ['c', 'c++', 'general']:
+                rule = join_path(dst, cfg)
+                #AEG:saving original for easier installation debug
+                save_original(rule)
+                filter_file(compOrig, compNew, rule, backup=False)
+        else:
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c'))
+            filter_file(compOrig, compNew, rule, backup=False)
+            filter_file(compOrigBaseGeneral, spack_cc, join_path(dst, 'c'),
+                        backup=False, string=True)
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c++'))
+            filter_file(compOrig, compNew, rule, backup=False)
+            filter_file(compOrigBaseGeneral + '++', spack_cxx, join_path(dst, 'c++'),
+                        backup=False, string=True)
+
+        src = join_path(general_rules, compOrigBaseGeneral)
+        dst = join_path(general_rules, compNew)
+        copy_tree(src, dst)
+        if self.spec.version >= Version('1906'):
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c'))
+            filter_file(compOrigBaseGeneral, spack_cc, join_path(dst, 'c'),
+                        backup=False, string=True)
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c++'))
+            filter_file(compOrigBaseGeneral + '++', spack_cxx, join_path(dst, 'c++'),
+                        backup=False, string=True)
+
+    #AEG: This additional function was needed for correct logic when using @when(@1812: %fj) for the fujitsu
+    @run_before('configure')
+    def call_make_pawsey_rules(self):
+        """Calling the correct Pawsey rules with @when
+        """
+        self.make_pawsey_rules()
+#-----
+#-----
+    #AEG: This additional function was needed for correct logic when using @when(@1812: %fj) for the fujitsu
+    def make_fujitsu_rules(self):
+        """Fujitsu rules when no @when applies
+        """
+        tty.info('Nothing to do for the fujitsu rules when no @when applies')
+
+    #AEG: Original function for the fujitsu rules:
+    @when('@1812: %fj')
+    def make_fujitsu_rules(self):
+        """Create Fujitsu rules (clang variant) unless supplied upstream.
+        Implemented for 1812 and later (older rules are too messy to edit).
+        Already included after 1912.
+        """
+        general_rules = 'wmake/rules/General'
+        arch_rules = 'wmake/rules/linuxARM64'  # self.arch
+        src = arch_rules + 'Clang'
+        dst = arch_rules + 'Fujitsu2'  # self.compiler
+        self.configure_trapFpe_off()  # LLVM may falsely trigger FPE
+
+        if os.path.exists(dst):
+            return
+
+        # Handle rules/<ARCH><COMP> or rules/<ARCH>/<COMP>
+        if not os.path.exists(src):
+            src = join_path(arch_rules, 'Clang')
+            dst = join_path(arch_rules, 'Fujitsu')  # self.compiler
+            if os.path.exists(dst):
+                return
+
+        tty.info('Add Fujitsu wmake rules')
+        copy_tree(src, dst)
+
+        if self.spec.version >= Version('1906'):
+            for cfg in ['c', 'c++', 'general']:
+                rule = join_path(dst, cfg)
+                #AEG:saving original for easier installation debug
+                save_original(rule)
+                filter_file('Clang', 'Fujitsu', rule, backup=False)
+        else:
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c'))
+            filter_file('clang', spack_cc, join_path(dst, 'c'),
+                        backup=False, string=True)
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c++'))
+            filter_file('clang++', spack_cxx, join_path(dst, 'c++'),
+                        backup=False, string=True)
+
+        src = join_path(general_rules, 'Clang')
+        dst = join_path(general_rules, 'Fujitsu')  # self.compiler
+        copy_tree(src, dst)
+        if self.spec.version >= Version('1906'):
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c'))
+            filter_file('clang', spack_cc, join_path(dst, 'c'),
+                        backup=False, string=True)
+            #AEG:saving original for easier installation debug
+            save_original(join_path(dst, 'c++'))
+            filter_file('clang++', spack_cxx, join_path(dst, 'c++'),
+                        backup=False, string=True)
+
+    #AEG: This additional function was needed for correct logic when using @when(@1812: %fj) for the fujitsu
+    @run_before('configure')
+    def call_make_fujitsu_rules(self):
+        """Calling the correct fujitsu rules with @when
+        """
+        self.make_fujitsu_rules()
+#-----
+
+    def configure(self, spec, prefix):
+        """Make adjustments to the OpenFOAM configuration files in their
+        various locations: etc/bashrc, etc/config.sh/FEATURE and
+        customizations that don't properly fit get placed in the etc/prefs.sh
+        file (similiarly for csh).
+        """
+        
+        # Filtering bashrc, cshrc
+        edits = {}
+        edits.update(self.foam_arch.foam_dict())
+        rewrite_environ_files(  # etc/{bashrc,cshrc}
+            edits,
+            posix=join_path('etc', 'bashrc'),
+            cshell=join_path('etc', 'cshrc'))
+
+        # Content for etc/prefs.{csh,sh}
+        self.etc_prefs = {
+            # TODO
+            # 'CMAKE_ARCH_PATH': spec['cmake'].prefix,
+            # 'FLEX_ARCH_PATH':  spec['flex'].prefix,
+            # 'ZLIB_ARCH_PATH':  spec['zlib'].prefix,
+        }
+
+        # MPI content, using MPI_ARCH_PATH
+        user_mpi = mplib_content(spec, '${MPI_ARCH_PATH}')
+
+        # Content for etc/config.{csh,sh}/ files
+        self.etc_config = {
+            'CGAL': [
+                #AEG: Adding the GMP and MPFR pieces
+                ('boost_version', 'boost_system'),
+                ('cgal_version', 'cgal_system'),
+                ('BOOST_ARCH_PATH', spec['boost'].prefix),
+                ('CGAL_ARCH_PATH',  spec['cgal'].prefix),
+                ('GMP_ARCH_PATH',  spec['gmp'].prefix),
+                ('MPFR_ARCH_PATH',  spec['mpfr'].prefix),
+                ('LD_LIBRARY_PATH',
+                 foam_add_lib(
+                     pkglib(spec['boost'], '${BOOST_ARCH_PATH}'),
+                     pkglib(spec['cgal'], '${CGAL_ARCH_PATH}'),
+                     pkglib(spec['gmp'], '${GMP_ARCH_PATH}'),
+                     pkglib(spec['mpfr'], '${MPFR_ARCH_PATH}'))),
+            ],
+            'FFTW': [
+                ('FFTW_ARCH_PATH', spec['fftw-api'].prefix),  # Absolute
+                ('LD_LIBRARY_PATH',
+                 foam_add_lib(
+                     pkglib(spec['fftw-api'], '${BOOST_ARCH_PATH}'))),
+            ],
+            # User-defined MPI
+            'mpi-user': [
+                ('MPI_ARCH_PATH', spec['mpi'].prefix),  # Absolute
+                ('LD_LIBRARY_PATH', foam_add_lib(user_mpi['libdir'])),
+                ('PATH', foam_add_path(user_mpi['bindir'])),
+            ],
+            'adios2': {},
+            'scotch': {},
+            'kahip': {},
+            'metis': {},
+            'ensight': {},     # Disable settings
+            'paraview': [],
+            'gperftools': [],  # Disable settings
+            'vtk': [],
+        }
+
+        # With adios2 after 1912
+        if spec.satisfies('@1912:'):
+            self.etc_config['adios2'] = [
+                ('ADIOS2_ARCH_PATH', spec['adios2'].prefix),
+                ('LD_LIBRARY_PATH',
+                 foam_add_lib(pkglib(spec['adios2'], '${ADIOS2_ARCH_PATH}'))),
+                ('PATH', foam_add_path('${ADIOS2_ARCH_PATH}/bin')),
+            ]
+
+        if '+scotch' in spec:
+            self.etc_config['scotch'] = {
+                'SCOTCH_ARCH_PATH': spec['scotch'].prefix,
+                # For src/parallel/decompose/Allwmake
+                'SCOTCH_VERSION': 'scotch-{0}'.format(spec['scotch'].version),
+            }
+
+        if '+kahip' in spec:
+            self.etc_config['kahip'] = {
+                'KAHIP_ARCH_PATH': spec['kahip'].prefix,
+            }
+
+        if '+metis' in spec:
+            self.etc_config['metis'] = {
+                'METIS_ARCH_PATH': spec['metis'].prefix,
+            }
+
+        # ParaView_INCLUDE_DIR is not used in 1812, but has no ill-effect
+        if '+paraview' in spec:
+            pvmajor = 'paraview-{0}'.format(spec['paraview'].version.up_to(2))
+            self.etc_config['paraview'] = [
+                ('ParaView_DIR', spec['paraview'].prefix),
+                ('ParaView_INCLUDE_DIR', '${ParaView_DIR}/include/' + pvmajor),
+                ('PV_PLUGIN_PATH', '$FOAM_LIBBIN/' + pvmajor),
+                ('PATH', foam_add_path('${ParaView_DIR}/bin')),
+            ]
+
+        if '+vtk' in spec:
+            self.etc_config['vtk'] = [
+                ('VTK_DIR', spec['vtk'].prefix),
+                ('LD_LIBRARY_PATH',
+                 foam_add_lib(pkglib(spec['vtk'], '${VTK_DIR}'))),
+            ]
+
+        # Optional
+        if '+mgridgen' in spec:
+            self.etc_config['mgridgen'] = {
+                'MGRIDGEN_ARCH_PATH': spec['parmgridgen'].prefix
+            }
+
+        # Optional
+        if '+zoltan' in spec:
+            self.etc_config['zoltan'] = {
+                'ZOLTAN_ARCH_PATH': spec['zoltan'].prefix
+            }
+
+        # Write prefs files according to the configuration.
+        # Only need prefs.sh for building, but install both for end-users
+        if self.etc_prefs:
+            write_environ(
+                self.etc_prefs,
+                posix=join_path('etc', 'prefs.sh'),
+                cshell=join_path('etc', 'prefs.csh'))
+
+        # Adjust components to use SPACK variants
+        for component, subdict in self.etc_config.items():
+            write_environ(
+                subdict,
+                posix=join_path('etc', 'config.sh',  component),
+                cshell=join_path('etc', 'config.csh', component))
+
+    def build(self, spec, prefix):
+        """Build using the OpenFOAM Allwmake script, with a wrapper to source
+        its environment first.
+        Only build if the compiler is known to be supported.
+        """
+        self.foam_arch.has_rule(self.stage.source_path)
+        self.foam_arch.create_rules(self.stage.source_path, self)
+
+        args = ['-silent']
+        if self.parallel:  # Build in parallel? - pass as an argument
+            args.append('-j{0}'.format(make_jobs))
+        builder = Executable(self.build_script)
+        builder(*args)
+
+    def install_write_location(self):
+        """Set the installation location (projectdir) in bashrc,cshrc."""
+        mkdirp(self.projectdir)
+
+        # Filtering: bashrc, cshrc
+        edits = {
+            'WM_PROJECT_DIR': self.projectdir,
+        }
+        etc_dir = join_path(self.projectdir, 'etc')
+        rewrite_environ_files(  # Adjust etc/bashrc and etc/cshrc
+            edits,
+            posix=join_path(etc_dir, 'bashrc'),
+            cshell=join_path(etc_dir, 'cshrc'))
+
+    @when('@:1806')
+    def install_write_location(self):
+        """Set the installation location (projectdir) in bashrc,cshrc.
+        In 1806 and earlier, had WM_PROJECT_INST_DIR as the prefix
+        directory where WM_PROJECT_DIR was installed.
+        """
+        mkdirp(self.projectdir)
+        projdir = os.path.basename(self.projectdir)
+
+        # Filtering: bashrc, cshrc
+        edits = {
+            'WM_PROJECT_INST_DIR': os.path.dirname(self.projectdir),
+            'WM_PROJECT_DIR': join_path('$WM_PROJECT_INST_DIR', projdir),
+        }
+        etc_dir = join_path(self.projectdir, 'etc')
+        rewrite_environ_files(  # Adjust etc/bashrc and etc/cshrc
+            edits,
+            posix=join_path(etc_dir, 'bashrc'),
+            cshell=join_path(etc_dir, 'cshrc'))
+
+    def install(self, spec, prefix):
+        """Install under the projectdir"""
+        mkdirp(self.projectdir)
+
+        # All top-level files, except spack build info and possibly Allwmake
+        if '+source' in spec:
+            ignored = re.compile(r'^spack-.*')
+        else:
+            ignored = re.compile(r'^(Allwmake|spack-).*')
+
+        files = [
+            f for f in glob.glob("*")
+            if os.path.isfile(f) and not ignored.search(f)
+        ]
+        for f in files:
+            install(f, self.projectdir)
+
+        # Having wmake and ~source is actually somewhat pointless...
+        # Install 'etc' before 'bin' (for symlinks)
+        # META-INFO for 1812 and later (or backported)
+        dirs = ['META-INFO', 'etc', 'bin', 'wmake']
+        if '+source' in spec:
+            dirs.extend(['applications', 'src', 'tutorials'])
+
+        for d in dirs:
+            if os.path.isdir(d):
+                install_tree(
+                    d,
+                    join_path(self.projectdir, d),
+                    symlinks=True)
+
+        dirs = ['platforms']
+        if '+source' in spec:
+            dirs.extend(['doc'])
+
+        # Install platforms (and doc) skipping intermediate targets
+        relative_ignore_paths = ['src', 'applications', 'html', 'Guides']
+        ignore = lambda p: p in relative_ignore_paths
+        for d in dirs:
+            install_tree(
+                d,
+                join_path(self.projectdir, d),
+                ignore=ignore,
+                symlinks=True)
+
+        self.install_write_location()
+        self.install_links()
+
+    def install_links(self):
+        """Add symlinks into bin/, lib/ (eg, for other applications)"""
+        # Make build log visible - it contains OpenFOAM-specific information
+        with working_dir(self.projectdir):
+            os.symlink(
+                join_path(os.path.relpath(self.install_log_path)),
+                join_path('log.' + str(self.foam_arch)))
+
+        if not self.config['link']:
+            return
+
+        # ln -s platforms/linux64GccXXX/lib lib
+        with working_dir(self.projectdir):
+            if os.path.isdir(self.archlib):
+                os.symlink(self.archlib, 'lib')
+
+        # (cd bin && ln -s ../platforms/linux64GccXXX/bin/* .)
+        with working_dir(join_path(self.projectdir, 'bin')):
+            for f in [
+                f for f in glob.glob(join_path('..', self.archbin, "*"))
+                if os.path.isfile(f)
+            ]:
+                os.symlink(f, os.path.basename(f))
+
+
+# -----------------------------------------------------------------------------
+
+class OpenfoamArch(object):
+    """OpenfoamArch represents architecture/compiler settings for OpenFOAM.
+    The string representation is WM_OPTIONS.
+
+    Keywords
+        label-size=[True]   supports int32/int64
+        compile-option[=-spack]
+        mplib[=USERMPI]
+    """
+
+    #: Map spack compiler names to OpenFOAM compiler names
+    #  By default, simply capitalize the first letter
+    compiler_mapping = {'aocc': 'Amd', 'fj': 'Fujitsu',
+                        'intel': 'Icc', 'oneapi': 'Icx'}
+
+    def __init__(self, spec, **kwargs):
+        # Some user settings, to be adjusted manually or via variants
+        self.compiler         = None   # <- %compiler
+        self.arch_option      = ''     # Eg, -march=knl
+        self.label_size       = None   # <- +int64
+        self.precision_option = 'DP'   # <- +float32 | +spdp
+        self.compile_option   = kwargs.get('compile-option', '-spack')
+        self.arch             = None
+        self.options          = None
+        self.mplib            = kwargs.get('mplib', 'USERMPI')
+
+        # WM_LABEL_OPTION, but perhaps not yet for foam-extend
+        if '+int64' in spec:
+            self.label_size = '64'
+        elif kwargs.get('label-size', True):
+            self.label_size = '32'
+
+        # WM_PRECISION_OPTION
+        if '+spdp' in spec:
+            self.precision_option = 'SPDP'
+        elif '+float32' in spec:
+            self.precision_option = 'SP'
+
+        # Processor/architecture-specific optimizations
+        if '+knl' in spec:
+            self.arch_option = '-march=knl'
+
+        # Capitalize first letter of compiler name to obtain the
+        # OpenFOAM naming (eg, gcc -> Gcc, clang -> Clang, etc).
+        # Use compiler_mapping[] for special cases
+        comp = spec.compiler.name
+        if comp in self.compiler_mapping:
+            comp = self.compiler_mapping[comp]
+
+        #AEG: updating the compiler if installing in a Cray:
+        plat = str(spec.architecture.platform)
+        tty.info('Spack Platform is set to {0}'.format(plat))
+        tty.info('Current compiler is set to {0}'.format(comp))
+        if plat == 'cray':
+            self.compiler = plat.capitalize() + comp.capitalize()
+        else:
+            self.compiler = comp.capitalize()
+        tty.info('Now compiler is set to {0}'.format(str(self.compiler)))
+        self.update_arch(spec)
+        self.update_options()
+
+    def update_arch(self, spec):
+        """Set WM_ARCH string corresponding to spack platform/target
+        """
+        # spec.architecture.platform is like `uname -s`, but lower-case
+        platform = str(spec.architecture.platform)
+        #AEG:Redefining platform to use rules as linuxXX<Compiler> instead of original problematic "cray<Compiler>"
+        tty.info('Spack defined platform is {0}'.format(platform))
+        if platform == 'cray':
+            platform = 'linux'
+            tty.info('Now platform is {0}'.format(platform))
+
+        # spec.target.family is like `uname -m`
+        target = str(spec.target.family)
+
+        # No spack platform family for ia64 or armv7l
+        if platform == 'linux':
+            if target == 'x86_64':
+                platform += '64'
+            elif target == 'ia64':
+                platform += 'IA64'
+            elif target == 'armv7l':
+                platform += 'ARM7'
+            elif target == 'aarch64':
+                # overwritten as 'Arm64' in openfoam-org
+                platform += 'ARM64'
+            elif target == 'ppc64':
+                platform += 'PPC64'
+            elif target == 'ppc64le':
+                platform += 'PPC64le'
+        elif platform == 'darwin':
+            if target == 'x86_64':
+                platform += '64'
+        # ... and others?
+        self.arch = platform
+
+    def update_options(self):
+        """Set WM_OPTIONS string consistent with current settings
+        """
+        # WM_OPTIONS
+        # ----
+        # WM_LABEL_OPTION=Int$WM_LABEL_SIZE
+        # WM_OPTIONS_BASE=$WM_ARCH$WM_COMPILER$WM_PRECISION_OPTION
+        # WM_OPTIONS=$WM_OPTIONS_BASE$WM_LABEL_OPTION$WM_COMPILE_OPTION
+        # or
+        # WM_OPTIONS=$WM_OPTIONS_BASE$WM_COMPILE_OPTION
+        # ----
+        self.options = ''.join([
+            self.arch,
+            self.compiler,
+            self.precision_option,
+            ('Int' + self.label_size if self.label_size else ''),
+            self.compile_option])
+
+    def __str__(self):
+        return self.options
+
+    def __repr__(self):
+        return str(self)
+
+    def foam_dict(self):
+        """Returns a dictionary for OpenFOAM prefs, bashrc, cshrc."""
+        return dict([
+            ('WM_COMPILER',    self.compiler),
+            ('WM_LABEL_SIZE',  self.label_size),
+            ('WM_PRECISION_OPTION', self.precision_option),
+            ('WM_COMPILE_OPTION', self.compile_option),
+            ('WM_MPLIB',       self.mplib),
+        ])
+
+    def _rule_directory(self, projdir, general=False):
+        """Return the wmake/rules/ General or compiler rules directory.
+        Supports wmake/rules/<ARCH><COMP> and wmake/rules/<ARCH>/<COMP>.
+        """
+        rules_dir = os.path.join(projdir, 'wmake', 'rules')
+        if general:
+            return os.path.join(rules_dir, 'General')
+
+        arch_dir = os.path.join(rules_dir, self.arch)
+        comp_rules = arch_dir + self.compiler
+        if os.path.isdir(comp_rules):
+            return comp_rules
+        else:
+            return os.path.join(arch_dir, self.compiler)
+
+    def has_rule(self, projdir):
+        """Verify that a wmake/rules/ compiler rule exists in the project.
+        """
+        # Insist on a wmake rule for this architecture/compiler combination
+        rule_dir = self._rule_directory(projdir)
+
+        if not os.path.isdir(rule_dir):
+            raise InstallError(
+                #AEG:'No wmake rule for {0} {1}'.format(self.arch, self.compiler))
+                'Failed to find the directory {0}\n'.format(rule_dir)
+                + 'No wmake rule for {0} {1}'.format(self.arch, self.compiler))
+        return True
+
+    def create_rules(self, projdir, foam_pkg):
+        """ Create {c,c++}-spack and mplib{USERMPI}
+        rules in the specified project directory.
+        The compiler rules are based on the respective {c,c++}Opt rules
+        but with additional rpath information for the OpenFOAM libraries.
+
+        The '-spack' rules channel spack information into OpenFOAM wmake
+        rules with minimal modification to OpenFOAM.
+        The rpath is used for the installed libpath (continue to use
+        LD_LIBRARY_PATH for values during the build).
+        """
+        # Note: the 'c' rules normally don't need rpath, since they are just
+        # used for some statically linked wmake tools, but left in anyhow.
+
+        # rpath for installed OpenFOAM libraries
+        rpath = '{0}{1}'.format(
+            foam_pkg.compiler.cxx_rpath_arg,
+            join_path(foam_pkg.projectdir, foam_pkg.archlib))
+
+        user_mpi = mplib_content(foam_pkg.spec)
+        rule_dir = self._rule_directory(projdir)
+
+        with working_dir(rule_dir):
+            # Compiler: copy existing cOpt,c++Opt and modify '*DBUG' value
+            for lang in ['c', 'c++']:
+                src = '{0}Opt'.format(lang)
+                dst = '{0}{1}'.format(lang, self.compile_option)
+                with open(src, 'r') as infile:
+                    with open(dst, 'w') as outfile:
+                        for line in infile:
+                            line = line.rstrip()
+                            outfile.write(line)
+                            if re.match(r'^\S+DBUG\s*=', line):
+                                outfile.write(' ')
+                                outfile.write(rpath)
+                            elif re.match(r'^\S+OPT\s*=', line):
+                                if self.arch_option:
+                                    outfile.write(' ')
+                                    outfile.write(self.arch_option)
+                            outfile.write('\n')
+
+            # MPI rules
+            for mplib in ['mplibUSERMPI']:
+                with open(mplib, 'w') as out:
+                    out.write("""# MPI from spack ({name})\n
+PFLAGS  = {FLAGS}
+PINC    = {PINC}
+PLIBS   = {PLIBS}
+#-------
+""".format(**user_mpi))
+
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
Failed Spec:
openfoam@v2012 +paraview +vtk
Mainly because of failure to install paraview which is giving troubles with osmesa and qt

Good Spec so far:
openfoam@v2012

Main modifications to make this work:
- New package.py recipe to allow set compilation with cray-gcc and fileHandler collated as default for the installation
- Modification of packages.yaml to allow for spack installation of texinfo