### PR TITLE
Update to yamls including critical fix to packages.yaml

### DIFF
--- a/setonix/configs_site_allusers/packages.yaml
+++ b/setonix/configs_site_allusers/packages.yaml
@@ -48,10 +48,6 @@ packages:
 
   # preferred versions (for 2022.01) and variants, utils
   # Note: setting autoconf/automake/cmake as non buildable
-  autoconf:
-    buildable: false
-  automake:
-    buildable: false
   cmake:
     version: [3.21.4]
 # Commented out - see GENERAL NOTES above
@@ -72,6 +68,12 @@ packages:
   python:
     version: [3.9.7]
     variants: '+optimizations'
+  gdbm:
+    version: [1.19]
+  sqlite:
+    version: [3.28.0]
+  gettext:
+    version: [0.19.8.1]
 # Commented out - see GENERAL NOTES above
 #    externals:
 #    - spec: python@3.9.7+optimizations
@@ -166,10 +168,10 @@ packages:
   plumed:
     version: [2.7.2]
   netlib-scalapack:
-    version: [@2.1.0]
+    version: [2.1.0]
   slate:
     version: [2021.05.02]
-    variants: 'cuda=off'
+    variants: '~cuda'
   trilinos:
     version: [13.0.1]
     variants: '+adios2 +openmp +python'
@@ -202,11 +204,11 @@ packages:
     - spec: bison@3.0.4
       prefix: /usr
     buildable: false
-#  bzip2:
-#    externals:
-#    - spec: bzip2@1.0.6
-#      prefix: /usr
-#    buildable: false
+  bzip2:
+    externals:
+    - spec: bzip2@1.0.6
+      prefix: /usr
+    buildable: false
   cpio:
     externals:
     - spec: cpio@2.12
@@ -309,14 +311,31 @@ packages:
     buildable: false
 
 # system packages (manually added)
-
-# packages that are missing dev install with zypper 
-# so commented out 
-#  binutils:
-#    externals:
-#    - spec: binutils@2.35.1
-#      prefix: /usr
-#    buildable: false
+  autoconf:
+    externals:
+    - spec: autoconf@2.69
+      prefix: /usr
+    buildable: false
+  autogen:
+    externals:
+    - spec: autogen@5.18.12
+      prefix: /usr
+    buildable: false
+  automake:
+    externals:
+    - spec: automake@1.15.1
+      prefix: /usr
+    buildable: false
+  binutils:
+    externals:
+    - spec: binutils@2.35.1
+      prefix: /usr
+    buildable: false
+  gettext:
+    externals:
+    - spec: gettext@0.19.8.1
+      prefix: /usr
+    buildable: false 
   hwloc:
     externals:
     - spec: hwloc@2.0.0
@@ -340,11 +359,16 @@ packages:
 #    - spec: ncurses@5.9
 #      prefix: /usr
     buildable: false
-#  numactl:
-#    externals:
-#    - spec: numactl@2.0.11
-#      prefix: /usr
-#    buildable: false
+  numactl:
+    externals:
+    - spec: numactl@2.0.11
+      prefix: /usr
+    buildable: false
+  sqlite:
+    externals:
+    - spec: sqlite@3.28.0
+      prefix: /usr
+    buildable: false
   curl:
     externals:
     - spec: curl@7.60.0
@@ -378,6 +402,56 @@ packages:
   zstd:
     externals:
     - spec: zstd@1.4.4
+      prefix: /usr
+    buildable: false
+  cryptsetup:
+    externals:
+    - spec: cryptsetup@2.0.6
+      prefix: /usr
+    buildable: false
+  libgpg-error:
+    externals:
+    - spec: libgpg-error@1.29
+      prefix: /usr
+    buildable: false
+  popt:
+    externals:
+    - spec: popt@1.16
+      prefix: /usr
+    buildable: false
+  icu4c:
+    externals:
+    - spec: icu4c@60.2
+      prefix: /usr
+    buildable: false 
+  lvm2:
+    externals:
+    - spec: lvm2@2.02
+      prefix: /usr
+    buildable: false
+  blkid:
+    externals:
+    - spec: blkid@2.33
+      prefix: /usr
+    buildable: false
+  squashfs:
+    externals:
+    - spec: squashfs@4.3
+      prefix: /usr
+    buildable: false
+  shadow: 
+    externals:
+    - spec: shadow@4.6
+      prefix: /usr
+    buildable: false
+  util-linux:
+    externals:
+    - spec: util-linux@2.33
+      prefix: /usr
+    buildable: false
+  util-linux-uuid:
+    externals:
+    - spec: util-linux-uuid@2.33
       prefix: /usr
     buildable: false
 

--- a/setonix/configs_site_allusers/packages.yaml
+++ b/setonix/configs_site_allusers/packages.yaml
@@ -163,7 +163,7 @@ packages:
   plasma:
     version: [20.9.20]
   petsc:
-    version: [3.15]
+    version: [3.15.5]
     variants: '+fftw +trilinos'
   plumed:
     version: [2.7.2]

--- a/setonix/environments/env_astro/spack.yaml
+++ b/setonix/environments/env_astro/spack.yaml
@@ -3,7 +3,6 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
-
   packages:
     py-numpy:
       version: [1.20.3]
@@ -13,7 +12,6 @@ spack:
       version: [1.7.1]
     py-setuptools:
       version: [57.4.0]
-
   definitions:
   
   # casacore variants
@@ -30,18 +28,19 @@ spack:
     - wcslib
 
   - askap-util-set:
-    - cppzmq 
-    - libzmq 
-    - apr 
-    - apr-util 
-    - gsl 
+    - cppzmq
+    - libzmq
+    - apr
+    - apr-util
+    - gsl
     - cppunit
-    - log4cxx 
-    - mcpp 
+    - log4cxx
+    - mcpp
     - xerces-c
-    - subversion 
+    - subversion
 
   - mwa-util-set:
+    
     # - swarp #swarp download page does not seem to be available
     # - wsclean # will need new recipe
     # - wctools # will need new recipe
@@ -76,7 +75,6 @@ spack:
   - matrix:
     - [$casacore-legacy]
     - ['%gcc@10.3.0 fflags=-fallow-argument-mismatch ^python@3.9.7 +optimizations']
-
   - matrix:
     - [$astro-util-set, $askap-util-set, $mwa-util-set]
     - ['%gcc@10.3.0 fflags=-fallow-argument-mismatch']
@@ -85,5 +83,4 @@ spack:
     - [$python-astro-set]
     - ['%gcc@10.3.0']
     - [^python@3.9.7 +optimizations]
-
   view: false

--- a/setonix/environments/env_num_libs/spack.yaml
+++ b/setonix/environments/env_num_libs/spack.yaml
@@ -34,7 +34,7 @@ spack:
     
     # adding blaspp 
     - blaspp ~cuda ^openblas
-    
+
     # updates to lapack/blas for new hardware like GPUs  
     # TODO: no need for magma in phase 1 as it is GPU only 
     #- magma@2.5.4 
@@ -42,17 +42,17 @@ spack:
     # issue with building with blas and lapack using cray-libsci. 
     # Moving to openblas as default address this issue 
     - plasma@20.9.20 ^openblas
-    
+
     # TODO: for slate@ unable to patch source commits
     # however, patch only required for cray-libsci builds
     # may be addressed with openblas 
     - slate@2021.05.02 ^openblas
     - plumed@2.7.2 ^python@3.9.7+optimizations
-    
+
     # some heavier numerical library builds 
     - opencv@4.5.2
     - trilinos@13.0.1 +adios2 +openmp +python ~cuda ^python@3.9.7 +optimizations
-    - petsc@3.15 +fftw +trilinos ~cuda
+    - petsc@3.15.5 +fftw +trilinos ~cuda
 
   specs:
   - matrix:

--- a/setonix/environments/env_num_libs/spack.yaml
+++ b/setonix/environments/env_num_libs/spack.yaml
@@ -1,45 +1,65 @@
 spack:
   packages:
-    blas::
+    'blas:':
       buildable: true
-    lapack::
+    'lapack:':
       buildable: true
-    scalapack::
+    'scalapack:':
       buildable: true
-    fftw-api::
+    'fftw-api:':
+      buildable: true
+    'fftw:':
       buildable: true
   definitions:
-  - packages:
-    - boost@1.76.0 +mpi +numpy +python
-    - eigen@3.4 # charris: build ok on Joey 2021-12-16
-    - fftw@2.1.5 +openmp precision=float,double,long_double
+  - parallel:
+    - boost@1.76.0 +mpi +numpy +python cxxstd=14 # might need several boosts with different stadards
+    - hpx@1.6.0 +async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi cxxstd=14
+      ^boost                                                                                 # charris: build okay on Joey 2021-12-16
+    
+    # rather stupidly kokkos has std=98,11, etc setting cxxstd. BUT all other packages 
+    # use the flag cxxstd ... Update in recipes might fix this but for the moment, we fix 
+    # this in our repo
+    - kokkos@3.4.01 +hwloc +memkind +numactl +openmp +tuning cxxstd=14
+    - kokkos@3.4.01 +hwloc +memkind +numactl +hpx +hpx_async_dispatch +tuning cxxstd=14
+      ^hpx@1.6.0 +async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi
+
+  - numerical:
+    - openblas@0.3.15 threads=openmp
+    - netlib-lapack@3.9.1
+    - netlib-scalapack@2.1.0
+    - eigen@3.4.0 # charris: build ok on Joey 2021-12-16
+    - fftw@2.1.5 +openmp precision=float,double # fftw 2 does not support long doubles
     - fftw@3.3.9 +openmp precision=float,double,long_double
     - gsl@2.6
-    - hpx@1.6.0 +async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi # charris: build okay on Joey 2021-12-16
-    - kokkos@3.4.01 +hwloc +memkind +numactl +openmp +tuning
-    - kokkos@3.4.01 +hwloc +memkind +numactl +hpx +hpx_async_dispatch +tuning ^hpx@1.6.0
-      +async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi
-    - netlib-lapack@3.9.1
-#    - magma@2.5.4 cuda=off  # this is GPU only
-    - openblas@0.3.15 threads=openmp
-    - opencv@4.5.2
+    
+    # adding blaspp 
+    - blaspp ~cuda ^openblas
+    
+    # updates to lapack/blas for new hardware like GPUs  
+    # TODO: no need for magma in phase 1 as it is GPU only 
+    #- magma@2.5.4 
     # for plasma@ setting blas and lapack buildable to true in spack.yaml file
     # issue with building with blas and lapack using cray-libsci. 
     # Moving to openblas as default address this issue 
     - plasma@20.9.20 ^openblas
-    - petsc@3.15 +fftw +trilinos
-    - plumed@2.7.2 ^python@3.9.7+optimizations
-    - netlib-scalapack@2.1.0
-    # adding blaspp 
-    - blaspp ^openblas
+    
     # TODO: for slate@ unable to patch source commits
     # however, patch only required for cray-libsci builds
     # may be addressed with openblas 
-    - slate@2021.05.02 ^openblas cuda=off
-    - trilinos@13.0.1 +adios2 +openmp +python ^python@3.9.7 +optimizations
+    - slate@2021.05.02 ^openblas
+    - plumed@2.7.2 ^python@3.9.7+optimizations
+    
+    # some heavier numerical library builds 
+    - opencv@4.5.2
+    - trilinos@13.0.1 +adios2 +openmp +python ~cuda ^python@3.9.7 +optimizations
+    - petsc@3.15 +fftw +trilinos ~cuda
+
   specs:
   - matrix:
-    - [$packages]
+    - [$parallel]
+    - ['%gcc@10.3.0']
+  - matrix:
+    - [$numerical]
     - ['%gcc@10.3.0']
 # TODO: ideally we would use all compilers/versions for num/io libraries
 #    - ['%gcc@10.3.0','%gcc@9.3.0','%gcc@8.1.0','%cce@12.0.1','%aocc@3.0.0']

--- a/setonix/environments/env_num_libs/spack.yaml
+++ b/setonix/environments/env_num_libs/spack.yaml
@@ -14,14 +14,16 @@ spack:
   - parallel:
     - boost@1.76.0 +mpi +numpy +python cxxstd=14 # might need several boosts with different stadards
     - hpx@1.6.0 +async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi cxxstd=14
-      ^boost                                                                                 # charris: build okay on Joey 2021-12-16
+      ^boost
     
     # rather stupidly kokkos has std=98,11, etc setting cxxstd. BUT all other packages 
     # use the flag cxxstd ... Update in recipes might fix this but for the moment, we fix 
     # this in our repo
     - kokkos@3.4.01 +hwloc +memkind +numactl +openmp +tuning cxxstd=14
-    - kokkos@3.4.01 +hwloc +memkind +numactl +hpx +hpx_async_dispatch +tuning cxxstd=14
-      ^hpx@1.6.0 +async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi
+    
+    # for hpx must explicitly set openmp off 
+    - kokkos@3.4.01 +hwloc +memkind +numactl +hpx +hpx_async_dispatch +tuning ~openmp
+      cxxstd=14 ^hpx@1.6.0 +async_mpi malloc=jemalloc max_cpu_count=128 networking=mpi
 
   - numerical:
     - openblas@0.3.15 threads=openmp
@@ -31,10 +33,8 @@ spack:
     - fftw@2.1.5 +openmp precision=float,double # fftw 2 does not support long doubles
     - fftw@3.3.9 +openmp precision=float,double,long_double
     - gsl@2.6
-    
-    # adding blaspp 
     - blaspp ~cuda ^openblas
-
+    
     # updates to lapack/blas for new hardware like GPUs  
     # TODO: no need for magma in phase 1 as it is GPU only 
     #- magma@2.5.4 
@@ -42,17 +42,22 @@ spack:
     # issue with building with blas and lapack using cray-libsci. 
     # Moving to openblas as default address this issue 
     - plasma@20.9.20 ^openblas
-
+    
     # TODO: for slate@ unable to patch source commits
     # however, patch only required for cray-libsci builds
     # may be addressed with openblas 
     - slate@2021.05.02 ^openblas
     - plumed@2.7.2 ^python@3.9.7+optimizations
-
+    
     # some heavier numerical library builds 
     - opencv@4.5.2
     - trilinos@13.0.1 +adios2 +openmp +python ~cuda ^python@3.9.7 +optimizations
-    - petsc@3.15.5 +fftw +trilinos ~cuda
+    
+    # TODO: currently unable to configure petsc with trilinos. 
+    # not clear if issue is with petsc or the version of trilinos
+    # for the moment trilinos disabled 
+    #- petsc@3.15.5 +fftw +trilinos +hwloc +openmp +complex ~cuda
+    - petsc@3.15.5 +fftw ~trilinos +hwloc +openmp +complex ~cuda
 
   specs:
   - matrix:

--- a/setonix/environments/env_python/spack.yaml
+++ b/setonix/environments/env_python/spack.yaml
@@ -19,9 +19,11 @@ spack:
     - py-matplotlib@3.4.3 +movies
     - py-mpi4py@3.1.2
     - py-netcdf4@1.5.3
-# py-numba: adding dependency explicitly to avoid spec error
+    
+    # py-numba: adding dependency explicitly to avoid spec error
     - py-numba@0.54.0 ^binutils+ld+gold
-# py-numpy: using specific version, which is the latest support by scipy right now
+   
+    # py-numpy: using specific version, which is the latest support by scipy right now
     - py-numpy@1.20.3
     - py-pandas@1.3.4
     - py-plotly@5.2.2
@@ -32,6 +34,7 @@ spack:
     - py-setuptools@57.4.0
 
   specs:
+  
 # TODO: check and enable cpu arch optimisations
   - matrix:
     - [python@3.9.7 +optimizations]
@@ -41,9 +44,8 @@ spack:
   - matrix:
     - [$packages, $utilities]
     - ['%gcc@10.3.0']
-# TODO: check and enable cpu arch optimisations
-#    - ['target=zen2', 'target=zen3']
     - [^python@3.9.7 +optimizations]
+  - python@3.9.7
   view: false
 # TODO: list python, py-pip and py-setuptools as external in packages.yaml
 # TODO: write module projections

--- a/setonix/environments/env_utils/spack.yaml
+++ b/setonix/environments/env_utils/spack.yaml
@@ -1,35 +1,46 @@
 spack:
   packages:
-# double colon in the next line, so that existing externals are ignored
     autoconf:
-      version: [2.71]
+      version: [2.69]
+    autogen:
+      version: [5.18.12]
     automake:
-      version: [1.16.3]
-    cmake::
+      version: [1.15.1]
+    'cmake:':
       version: [3.21.4]
       buildable: true
   definitions:
   - packages:
+    
 # py-pip and py-setuptools: installed in env_python
 # snakemake: docs recommend to install with conda
-#    - autoconf@2.71  # this will come from rpm # charris: build ok on Joey 2021-12-15
-#    - automake@1.16.3  # this will come from rpm # charris: build ok on Joey 2021-12-15
     - cmake@3.21.4
-#    - emacs@27.2 +X toolkit=gtk  # this will come from rpm
     - ffmpeg@4.4 +avresample
     - gnuplot@5.4.2 +X
-    - matlab@R2021a key=$MATLAB_INSTALL_KEY mode=automated
-#    - nano@5.7  # this will come from rpm
     - nextflow@21.10.5 ^openjdk@17.0.0_35
     - parallel@20210922
     - reframe@3.6.1 ^python@3.9.7 +optimizations
-    - singularity@3.8.5
+    - singularity@3.8.5 ^python@3.9.7 +optimizations
+  - licensed:
+    - matlab@R2021a key=$MATLAB_INSTALL_KEY mode=automated
   specs:
   - matrix:
     - [$packages]
     - ['%gcc@10.3.0']
+# TODO: build licensed software
+  # - matrix:
+  #   - [$licensed]
+  #   - ['%gcc@10.3.0']
 # TODO: enable target
 #    - ['target=zen2']
+  - libgpg-error
+  - libseccomp
+  - autoconf
+  - automake
+  - shadow
+  - squashfs
+  - cryptsetup
+  - pkg-config
   view: false
 # TODO: list as external in packages.yaml
 # TODO: write module projections


### PR DESCRIPTION
cuda=off typo resulted in issues with `spec slate` 

Also reorganised the num_libs which does contain not just numerical libraries but parallelism libraries. 