### PR TITLE
setonix site config: removed unnecessary version prefs for 2x externals

### DIFF
--- a/setonix/configs_site_allusers/packages.yaml
+++ b/setonix/configs_site_allusers/packages.yaml
@@ -70,10 +70,6 @@ packages:
     variants: '+optimizations'
   gdbm:
     version: [1.19]
-  sqlite:
-    version: [3.28.0]
-  gettext:
-    version: [0.19.8.1]
 # Commented out - see GENERAL NOTES above
 #    externals:
 #    - spec: python@3.9.7+optimizations


### PR DESCRIPTION
Before the edit, packages.yaml had two entries for sqlite and gettext;
YAML parsing is only able to manage one entry for each key (can't recall which one gets to be used, probably the latest in parsing order).

In this PR, I have got rid of the version preferences for sqlite and gettext;
this was not needed any way, because the other entry for these two packages sets them as externals and non buildable, with the desired versions.