### PR TITLE
setonix packages.yaml: edit to permission settings

### DIFF
--- a/setonix/configs_site_allusers/packages.yaml
+++ b/setonix/configs_site_allusers/packages.yaml
@@ -13,8 +13,11 @@ packages:
       pkgconfig: [ pkg-config ]
     permissions:
       read: world
-      write: group
-      group: pawsey0001
+      # this should be user, we do not want pawsey0001 users 
+      # to accidentally edit the system wide installation
+      write: user
+      # using $PAWSEY_PROJECT will work for all users
+      group: $PAWSEY_PROJECT
 
 # don't build virtuals with an external provider
   mpi:


### PR DESCRIPTION
- I have changed default write settings to "user", to avoid Pawsey staff inadvertently editing the system wide installation outside of the "spack" user
- I have changed the group ownership from "pawsey0001" to "$PAWSEY_PROJECT", so that it works for all users