### PR TITLE
setonix: repos/templates only from pawsey-config path

### DIFF
--- a/setonix/configs_site_allusers/config.yaml
+++ b/setonix/configs_site_allusers/config.yaml
@@ -4,11 +4,6 @@ config:
   install_tree:
     root: /software/$PAWSEY_PROJECT/$USER/setonix/software
 
-  # Locations where templates should be found
-  template_dirs:
-# this one is only for end-users
-    - /software/$PAWSEY_PROJECT/$USER/setonix/templates_setonix
-
   # Temporary locations Spack can try to use for builds.
   #
   # Recommended options are given below.

--- a/setonix/configs_site_allusers/repos.yaml
+++ b/setonix/configs_site_allusers/repos.yaml
@@ -3,7 +3,6 @@ repos:
 # in that items higher up in the list are inspected first
 # and take precedence
 # 
-# this one should only be used by end-users (and be empty for the Spack user)
-- /software/$PAWSEY_PROJECT/$USER/setonix/repo_setonix
-# Spack user (Pawsey staff) should populate this one
+# Spack user (Pawsey staff) populates this one with fixed recipes for Setonix
+# that are not (yet) in the Spack public repo
 - /software/setonix/2022.01/pawsey-spack-config/setonix/repo_setonix

--- a/setonix/configs_spackuser_pawseystaff/config.yaml
+++ b/setonix/configs_spackuser_pawseystaff/config.yaml
@@ -7,6 +7,7 @@ config:
   # Locations where templates should be found
   template_dirs:
 # this one is only for the Spack user (Pawsey staff)
+# some of the edits here are specific to the system-wide modules configuration
     - /software/setonix/2022.01/pawsey-spack-config/setonix/templates_setonix
 
   # Temporary locations Spack can try to use for builds.

--- a/setonix/extras/marco-setup-joey.sh
+++ b/setonix/extras/marco-setup-joey.sh
@@ -21,7 +21,6 @@ cp -p pawsey-spack-config/setonix/fixes/microarchitectures.json spack/lib/spack/
 patch spack/lib/spack/spack/modules/lmod.py pawsey-spack-config/setonix/fixes/lmod_arch_family.patch
 
 # Joey specific
-sed -i '/USER/ s;^;#;g' spack/etc/spack/repos.yaml
 # this is the date tag to be replaced in the config yamls, with the current directory
 date_tag="2022.01"
 install_dir="$(pwd)"


### PR DESCRIPTION
The previous repo setup I did was scanning:
1. a USER specific location for recipes (would be empty for vast majority of users)
2. the setonix location with our Pawsey fixed recipes

In this setup, if a repo is empty, Spack will print a warning at every command, which I reckon can be annoying/distracting.

Considering not many users are likely to need to edit recipes, this PR does two things:
1. removes the USER specific location for recipes (`repos.yaml`)
2. for consistency with 1., also removes the USER specific location for templates (`config.yaml`). There's no warning here. However, considering that also this one is likely to be empty for most users, I though of let consistency prevail.

For powerusers of Spack, we can document how to customise their `~/.spack` yamls to edit these things.

Thoughts?