### PR TITLE
Update to the autoload of modules. Now default is direct

### DIFF
--- a/setonix/configs_site_allusers/modules.yaml
+++ b/setonix/configs_site_allusers/modules.yaml
@@ -55,6 +55,9 @@ modules:
           # this may be required for installs on Topaz
           #set:
           #  'MAALI_{name}_HOME': '{prefix}'
+        # for libraries make sure to load direct dependencies
+        autoload: direct
+      
     
       # select all packages that depend on python 
       # and set these modules to autoload their dependencies

--- a/setonix/configs_spackuser_pawseystaff/modules.yaml
+++ b/setonix/configs_spackuser_pawseystaff/modules.yaml
@@ -32,15 +32,19 @@ modules:
         autoload: none
       vasp:
         autoload: none
+      exabayes:
+        autoload: none
+      examl:
+        autoload: none
+      # s3 clients 
+      # awscli and py-boto not set to none
+      # as they depend on python
       miniocli:
         autoload: none
       rclone:
         autoload: none
+      # benchmarking 
       hpl:
-        autoload: none
-      exabayes:
-        autoload: none
-      examl:
         autoload: none
 
       # select all packages that depend on python

--- a/setonix/configs_spackuser_pawseystaff/modules.yaml
+++ b/setonix/configs_spackuser_pawseystaff/modules.yaml
@@ -5,6 +5,51 @@ modules:
       lmod: /software/setonix/2022.01/modules
 
     lmod:
+
+      # for applications for which it is unlikely
+      # dependencies are needed, set autoload to none
+      gromacs:
+        autoload: none
+      amber:
+        autoload: none
+      cpmd:
+        autoload: none
+      cp2k:
+        autoload: none
+      lammps:
+        autoload: none
+      namd:
+        autoload: none
+      nektar:
+        autoload: none
+      nwchem:
+        autoload: none
+      openfoam:
+        autoload: none
+      openfoam-org:
+        autoload: none
+      quantum-espresso:
+        autoload: none
+      vasp:
+        autoload: none
+      miniocli:
+        autoload: none
+      rclone:
+        autoload: none
+      awscli:
+        autoload: none
+      hpl:
+        autoload: none
+      exabayes:
+        autoload: none
+      examl:
+        autoload: none
+
+      # select all packages that depend on python
+      # and set these modules to autoload their dependencies
+      ^python:
+        autoload: direct
+
       projections:
         # modules on magnus have one of [apps, tools, python, devel] as start of module name 
         # an then {name}/{version}'
@@ -53,6 +98,7 @@ modules:
         kokkos: 'libraries/{name}/{version}/module'
         netlib-lapack: 'libraries/{name}/{version}/module'
         openblas: 'libraries/{name}/{version}/module'
+        blaspp: 'libraries/{name}/{version}/module'
         opencv: 'libraries/{name}/{version}/module'
         plasma: 'libraries/{name}/{version}/module'
         petsc: 'libraries/{name}/{version}/module'

--- a/setonix/configs_spackuser_pawseystaff/modules.yaml
+++ b/setonix/configs_spackuser_pawseystaff/modules.yaml
@@ -36,8 +36,6 @@ modules:
         autoload: none
       rclone:
         autoload: none
-      awscli:
-        autoload: none
       hpl:
         autoload: none
       exabayes:


### PR DESCRIPTION
unless specifically set otherwise.

This address the issue of modules not loading dependencies by default which is an issue for all libraries. The use of Rpath means that this is not an issue for applications and hence these applications will by default NOT autoload anything. 

