### PR TITLE
Update/modules stuff

### DIFF
--- a/setonix/configs_site_allusers/config.yaml
+++ b/setonix/configs_site_allusers/config.yaml
@@ -4,6 +4,12 @@ config:
   install_tree:
     root: /software/$PAWSEY_PROJECT/$USER/setonix/software
 
+  # Locations where templates should be found
+  template_dirs:
+  # This is now for all users
+  # Some edits are useful to everyone, none has known side effects for end users
+    - /software/setonix/2022.01/pawsey-spack-config/setonix/templates_setonix
+
   # Temporary locations Spack can try to use for builds.
   #
   # Recommended options are given below.

--- a/setonix/configs_spackuser_pawseystaff/config.yaml
+++ b/setonix/configs_spackuser_pawseystaff/config.yaml
@@ -4,12 +4,6 @@ config:
   install_tree:
     root: /software/setonix/2022.01/software
 
-  # Locations where templates should be found
-  template_dirs:
-# this one is only for the Spack user (Pawsey staff)
-# some of the edits here are specific to the system-wide modules configuration
-    - /software/setonix/2022.01/pawsey-spack-config/setonix/templates_setonix
-
   # Temporary locations Spack can try to use for builds.
   #
   # Recommended options are given below.

--- a/setonix/templates_setonix/modules/modulefile.lua
+++ b/setonix/templates_setonix/modules/modulefile.lua
@@ -68,9 +68,9 @@ setenv("LMOD_{{ name|upper() }}_VERSION", "{{ version_part }}")
 {% block autoloads %}
 {% for module in autoload %}
 {% if verbose %}
-LmodMessage("Autoloading {{ module |replace("astro-applications/", "") |replace("bio-applications/", "") |replace("applications/", "") |replace("libraries/", "") |replace("programming-languages/", "") |replace("utilities/", "") |replace("visualisation/", "") |replace("python-packages/", "") |replace("benchmarking/", "") |replace("dependencies/", "") }}")
+LmodMessage("Autoloading {{ module |replace("astro-applications/", "") |replace("bio-applications/", "") |replace("py-keras-applications/", "pawsey-temporary-string/") |replace("applications/", "") |replace("pawsey-temporary-string/", "py-keras-applications/") |replace("libraries/", "") |replace("programming-languages/", "") |replace("utilities/", "") |replace("visualisation/", "") |replace("python-packages/", "") |replace("benchmarking/", "") |replace("dependencies/", "") }}")
 {% endif %}
-load("{{ module |replace("astro-applications/", "") |replace("bio-applications/", "") |replace("applications/", "") |replace("libraries/", "") |replace("programming-languages/", "") |replace("utilities/", "") |replace("visualisation/", "") |replace("python-packages/", "") |replace("benchmarking/", "") |replace("dependencies/", "") }}")
+load("{{ module |replace("astro-applications/", "") |replace("bio-applications/", "") |replace("py-keras-applications/", "pawsey-temporary-string/") |replace("applications/", "") |replace("pawsey-temporary-string/", "py-keras-applications/") |replace("libraries/", "") |replace("programming-languages/", "") |replace("utilities/", "") |replace("visualisation/", "") |replace("python-packages/", "") |replace("benchmarking/", "") |replace("dependencies/", "") }}")
 {% endfor %}
 {% endblock %}
 

--- a/setonix/templates_setonix/modules/modulefile.lua
+++ b/setonix/templates_setonix/modules/modulefile.lua
@@ -93,6 +93,8 @@ unsetenv("{{ cmd.name }}")
 {% endif %}
 {% if spec.name == 'openjdk' %}setenv("GRADLE_USER_HOME",os.getenv("MYSOFTWARE").."/.gradle")
 {% endif %}
+{% if spec.name == 'singularity' %}setenv("SINGULARITY_CACHEDIR",os.getenv("MYSOFTWARE").."/.singularity")
+{% endif %}
 
 {% block footer %}
 -- Access is granted only to specific groups


### PR DESCRIPTION
A couple of notable edits here:

1. a fix in the LUA template, to protect a specific package, `py-keras-applications` from being filtered out in autoload by the replacement filters
2. Pawsey custom templates used by default by all users site-wide, rather than only Spack user: achieved by moving `template_dirs` setting from the `spackuser`  to the `site` wide config. Reason: some of the customisations improve the behaviour, some add useful information, none has side effects for end users