### PR TITLE
setonix setup: added patches for Pascal,s enhancements to modulefiles

### DIFF
--- a/setonix/fixes/modulenames_plus_common.patch
+++ b/setonix/fixes/modulenames_plus_common.patch
@@ -1,0 +1,38 @@
+diff --git a/lib/spack/spack/modules/common.py b/lib/spack/spack/modules/common.py
+index 8855e57e64..ff3212436b 100644
+--- a/lib/spack/spack/modules/common.py
++++ b/lib/spack/spack/modules/common.py
+@@ -68,9 +68,11 @@ def configuration(module_set_name):
+ _valid_tokens = (
+     'name',
+     'version',
++    'variants',
+     'compiler',
+     'compiler.name',
+     'compiler.version',
++    'compiler_flags',
+     'architecture',
+     # tokens from old-style format strings
+     'package',
+@@ -605,8 +607,9 @@ def use_name(self):
+             projection = self.conf.default_projections['all']
+ 
+         name = self.spec.format(projection)
+-        # Not everybody is working on linux...
+-        parts = name.split('/')
++        # Not everybody is working on linux... so split on /
++        # Remove " " from the module name 
++        parts = name.replace(" ","_").replace('"',"_").split('/')
+         name = os.path.join(*parts)
+         # Add optional suffixes based on constraints
+         path_elements = [name] + self.conf.suffixes
+@@ -847,6 +850,9 @@ def write(self, overwrite=False):
+             tty.debug(msg.format(self.spec.cshort_spec))
+             return
+ 
++        # store the installation time of the package 
++        self.spec.installation_time = datetime.datetime.fromtimestamp(os.path.getmtime(self.spec.prefix)).strftime('%c')
++
+         # Print a warning in case I am accidentally overwriting
+         # a module file that is already there (name clash)
+         if not overwrite and os.path.exists(self.layout.filename):

--- a/setonix/fixes/modulenames_plus_init.patch
+++ b/setonix/fixes/modulenames_plus_init.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/spack/spack/cmd/modules/__init__.py b/lib/spack/spack/cmd/modules/__init__.py
+index 2098e67b73..13a9407901 100644
+--- a/lib/spack/spack/cmd/modules/__init__.py
++++ b/lib/spack/spack/cmd/modules/__init__.py
+@@ -309,6 +309,7 @@ def refresh(module_type, specs, args):
+                 for x in writer_list:
+                     message += 'spec: {0}\n'.format(x.spec.format())
+         tty.error(message)
++        tty.error("Consider updating naming convention to include hash")
+         tty.error('Operation aborted')
+         raise SystemExit(1)
+ 

--- a/setonix/setup/setup_spack.sh
+++ b/setonix/setup/setup_spack.sh
@@ -28,6 +28,10 @@ cp -p pawsey-spack-config/setonix/configs_spackuser_pawseystaff/*.yaml ~/.spack/
 
 # apply fixes into spack tree
 cp -p pawsey-spack-config/setonix/fixes/microarchitectures.json spack/lib/spack/external/archspec/json/cpu/
+# Marco,s Lmod arch family fix for the module tree
 patch spack/lib/spack/spack/modules/lmod.py pawsey-spack-config/setonix/fixes/lmod_arch_family.patch
+# Pascal,s enhancements to modulefiles
+patch lib/spack/spack/modules/common.py modulenames_plus_common.patch
+patch lib/spack/spack/cmd/modules/__init__.py modulenames_plus_init.patch
 
 # TODO: use $date_tag above to update across the spack yamls


### PR DESCRIPTION
@pelahi , I have turned your Spack branch with the extra modulefiles features, into two patches that can be applied to the stable branch.

My rationale is, for features that won't enter Spack's develop soon (eg because they're Pawsey specific), probably better to have them in the form of patches in this repo, as they maybe easier to locate, characterise and maintain over time.

Thoughts?

If it seems fine to you, please go ahead and merge.
