### PR TITLE
Update/environments remove preferred deps

### DIFF
--- a/setonix/environments/env_apps/spack.yaml
+++ b/setonix/environments/env_apps/spack.yaml
@@ -7,9 +7,9 @@ spack:
 # charris: wrf recipe, user installs, see wrf.yaml
     - amber@20 +openmp
     - cpmd@4.3 +mpi +omp
-    - cp2k@8.2 +plumed ^plumed@2.7.2 ^python@3.9.7+optimizations
-    - gromacs@2020.2 +double +lapack +plumed ^plumed@2.6.1 ^python@3.9.7+optimizations
-    - gromacs@2021.4 +double +lapack +plumed ^plumed@2.7.2 ^python@3.9.7+optimizations
+    - cp2k@8.2 +plumed ^plumed@2.7.2
+    - gromacs@2020.2 +double +lapack +plumed ^plumed@2.6.1
+    - gromacs@2021.4 +double +lapack +plumed ^plumed@2.7.2
     - lammps@20210929 +asphere +body +class2 +colloid +compress +coreshell +dipole
       +ffmpeg +granular +jpeg +kim +kokkos +kspace +latte +manybody +mc +misc +mliap
       +molecule +mpiio +opt +peri +png +poems +python +qeq +replica +rigid +shock
@@ -19,11 +19,10 @@ spack:
       +user-mofff +user-netcdf +user-omp +user-phonon +user-plumed +user-ptm +user-qtb
       +user-reaction +user-reaxc +user-sdpd +user-smd +user-smtbq +user-sph +user-tally
       +user-uef +user-yaff ^kokkos@3.4.01+hwloc+memkind+numactl+openmp+tuning ^plumed@2.7.2
-      ^python@3.9.7+optimizations
 
     
 # TODO: charmpp+namd yet to be made to work with Shasta/Slingshot
-    - namd@2.14 interface=python fftw=3 ^python@3.9.7+optimizations ^charmpp@7.0.0
+    - namd@2.14 interface=python fftw=3 ^charmpp@7.0.0
       backend=mpi
 
     

--- a/setonix/environments/env_astro/spack.yaml
+++ b/setonix/environments/env_astro/spack.yaml
@@ -58,7 +58,7 @@ spack:
   - matrix:
     - [$casacore-set]
     - ['%gcc@10.3.0']
-    - [+python build_type=Release ^python@3.9.7 +optimizations]
+    - [+python build_type=Release]
     - [+openmp, ~openmp]
     - [~adios2 ~hdf5, +adios2 +hdf5 ^adios2@2.7.1 +hdf5 ^hdf5@1.12.1 +hl +fortran
         +szip api=v112]
@@ -66,7 +66,6 @@ spack:
   - matrix:
     - [$casacore-legacy]
     - ['%gcc@10.3.0']
-    - [^python@3.9.7 +optimizations]
 #    - ['^fftw@3.3.9 +openmp precision=float,double,long_double']
   - matrix:
     - [$astro-util-set, $askap-util-set, $mwa-util-set]
@@ -74,5 +73,4 @@ spack:
   - matrix:
     - [$python-astro-set]
     - ['%gcc@10.3.0']
-    - [^python@3.9.7 +optimizations]
   view: false

--- a/setonix/environments/env_langs/spack.yaml
+++ b/setonix/environments/env_langs/spack.yaml
@@ -19,5 +19,4 @@ spack:
 # TODO: enable targets
 #    - ['target=zen2']
   view: false
-# TODO: list as external in packages.yaml
 # TODO: modules as core modules

--- a/setonix/environments/env_num_libs/spack.yaml
+++ b/setonix/environments/env_num_libs/spack.yaml
@@ -47,12 +47,12 @@ spack:
     # however, patch only required for cray-libsci builds
     # may be addressed with openblas 
     - slate@2021.05.02 ^openblas
-    - plumed@2.7.2 ^python@3.9.7+optimizations
+    - plumed@2.7.2
     
     # some heavier numerical library builds 
     - opencv@4.5.2
     - opencv@3.4.12
-    - trilinos@13.0.1 +adios2 +openmp +python ~cuda ^python@3.9.7 +optimizations
+    - trilinos@13.0.1 +adios2 +openmp +python ~cuda
     
     # TODO: currently unable to configure petsc with trilinos. 
     # not clear if issue is with petsc or the version of trilinos

--- a/setonix/environments/env_python/spack.yaml
+++ b/setonix/environments/env_python/spack.yaml
@@ -36,8 +36,5 @@ spack:
   - matrix:
     - [$packages, $utilities]
     - ['%gcc@10.3.0']
-    - [^python@3.9.7 +optimizations]
-  - python@3.9.7
   view: false
-# TODO: list python, py-pip and py-setuptools as external in packages.yaml
 # TODO: python, py-pip and py-setuptools modules as core modules

--- a/setonix/environments/env_s3_clients/spack.yaml
+++ b/setonix/environments/env_s3_clients/spack.yaml
@@ -16,7 +16,6 @@ spack:
   specs:
   - matrix:
     - [$s3-python-set]
-    - [^python@3.9.7 +optimizations]
     - ['%gcc@10.3.0']
   - matrix:
     - [$s3-go-set]

--- a/setonix/environments/env_utils/spack.yaml
+++ b/setonix/environments/env_utils/spack.yaml
@@ -8,7 +8,7 @@ spack:
     - cmake@3.21.4
     - ffmpeg@4.4 +avresample
     - gnuplot@5.4.2 +X  #^gettext@0.21
-    - nextflow@21.10.5 ^openjdk@17.0.0_35
+    - nextflow@21.10.5
     - parallel@20210922
     - reframe@3.6.1
     - singularity@3.8.5

--- a/setonix/environments/env_utils/spack.yaml
+++ b/setonix/environments/env_utils/spack.yaml
@@ -10,8 +10,8 @@ spack:
     - gnuplot@5.4.2 +X  #^gettext@0.21
     - nextflow@21.10.5 ^openjdk@17.0.0_35
     - parallel@20210922
-    - reframe@3.6.1 ^python@3.9.7 +optimizations
-    - singularity@3.8.5 ^python@3.9.7 +optimizations
+    - reframe@3.6.1
+    - singularity@3.8.5
   - licensed:
     - matlab@R2021a key=$MATLAB_INSTALL_KEY mode=automated
   specs:
@@ -24,15 +24,6 @@ spack:
   #   - ['%gcc@10.3.0']
 # TODO: enable target
 #    - ['target=zen2']
-  - libgpg-error
-  - libseccomp
-  - autoconf
-  - automake
-  - shadow
-  - squashfs
-  - cryptsetup
-  - pkg-config
-  #- libxpm ^gettext@0.21
   view: false
 # TODO: list as external in packages.yaml
 # TODO: modules as core modules

--- a/setonix/environments/env_vis/spack.yaml
+++ b/setonix/environments/env_vis/spack.yaml
@@ -13,5 +13,4 @@ spack:
 #    - ['%gcc@10.3.0', '%cce@12.0.1', '%aocc@3.0.0']
 # TODO: check and enable cpu arch optimisations
 #    - ['target=zen2', 'target=zen3']
-    - [^python@3.9.7 +optimizations]
   view: false


### PR DESCRIPTION
- removed  `^python@3.9.7 +optimizations` from environments, as it's already specified in packages.yaml (setup easier to maintain)
- on similar line, removed `^openjdk@<version>` for nextflow in env_utils