### PR TITLE
Update to amber recipe

### DIFF
--- a/setonix/repo_setonix/packages/amber/aarch64.patch
+++ b/setonix/repo_setonix/packages/amber/aarch64.patch
@@ -1,0 +1,24 @@
+--- a/ambertools_tmpdir/AmberTools/src/fftw-3.3/config.guess	2020-09-30 13:28:45.035344970 -0700
++++ b/ambertools_tmpdir/AmberTools/src/fftw-3.3/config.guess	2020-09-30 13:28:55.534923364 -0700
+@@ -858,6 +858,9 @@
+     i*86:Minix:*:*)
+ 	echo ${UNAME_MACHINE}-pc-minix
+ 	exit ;;
++    aarch64:Linux:*:*)
++	echo aarch64-unknown-linux-gnu
++	exit ;;
+     alpha:Linux:*:*)
+ 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
+ 	  EV5)   UNAME_MACHINE=alphaev5 ;;
+--- a/ambertools_tmpdir/AmberTools/src/xblas/config/config.guess	2020-09-30 15:30:11.573779015 -0700
++++ b/ambertools_tmpdir/AmberTools/src/xblas/config/config.guess	2020-09-30 15:30:46.932366326 -0700
+@@ -863,6 +863,9 @@
+     i*86:Minix:*:*)
+ 	echo ${UNAME_MACHINE}-pc-minix
+ 	exit ;;
++    aarch64:Linux:*:*)
++       echo aarch64-unknown-linux-gnu
++       exit ;;
+     alpha:Linux:*:*)
+ 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
+ 	  EV5)   UNAME_MACHINE=alphaev5 ;;

--- a/setonix/repo_setonix/packages/amber/ambertools_configure2.patch
+++ b/setonix/repo_setonix/packages/amber/ambertools_configure2.patch
@@ -1,0 +1,294 @@
+--- a/ambertools_tmpdir/AmberTools/src/configure2	2022-01-17 13:00:06.000000000 +0800
++++ b/ambertools_tmpdir/AmberTools/src/configure2	2022-01-14 15:59:29.000000000 +0800
+@@ -11,7 +11,7 @@
+ cat<<EOD
+ Usage: ./configure [flags] compiler
+ 
+-    where compiler is one of: [[ gnu, intel, pgi, clang, or cray ]]
++    where compiler is one of: [[ gnu, intel, pgi, clang, or cray, cray-shasta-gnu, cray-shasta-cray, cray-shasta-aocc ]]
+ 
+                               COMPILERS
+                  -------------------------------------------------------------
+@@ -488,6 +488,7 @@
+ has_boost=''
+ installtype='serial'
+ intelmpi='no'
++craympi='no'
+ is_mac='no'
+ ldflags=''
+ ld='ld '
+@@ -1375,7 +1376,7 @@
+       fflags="$fflags -g"
+     fi
+ 
+-    extract_and_emit_compiler_versions '-v'
++    extract_and_emit_compiler_versions '--version'
+ 
+     if [ $cc_version_major -ge 4 -a $cc_version_minor -ge 2 -a "$optimise" = "yes" ]; then
+       if [ $sse = 'yes' ]; then
+@@ -1590,7 +1591,7 @@
+         fflags="$fflags -g -debug all"
+     fi
+ 
+-    extract_and_emit_compiler_versions '-v'
++    extract_and_emit_compiler_versions '--version'
+ 
+     # Intel 18.0.x not ready for prime time; srb mar 26, 2018; see
+     # [AMBER-Developers] Intel compilers and Amber18
+@@ -2044,21 +2045,18 @@
+ #################### cray #######
+ cray)
+     test -z "$pic" && pic="-fpic"
+-    if [ "$intelmpi" = 'yes' ]; then
+-      echo "Intel MPI requires the intel compilers."
+-      exit 1
+-    fi
++    craympi='yes'
+     ld='ftn'
+     flibs_arch=""
+     flibsf_arch=
+     cc=cc
+-    cflags="$pic"
++    cflags="$pic -O3"
+     ambercflags=""
+     cplusplus=CC
+-    cxxflags="$pic"
++    cxxflags="$pic -O3"
+     ambercxxflags=""
+     fc=ftn
+-    fflags="$pic"
++    fflags="$pic -O3"
+     # The -lstdc++ flag gives lots of duplicate symbol errors with cray
+     fc_cxx_link_flag=""
+ 
+@@ -2083,6 +2081,7 @@
+     #       -D_FILE_OFFSET_BITS etc.) cray compilers need '-h gnu'.
+     #       Also, the fortran compile requires '-emf' to force
+     #       the build of module files with all-lowercase names.
++    # old cray compilers
+     if [ "$optimise" = 'no' ]; then
+       cflags="$cflags -O0 $cray_omp_flag -h gnu"
+       cnooptflags=""
+@@ -2113,7 +2112,7 @@
+       fflags="$fflags -g"
+     fi
+ 
+-    extract_and_emit_compiler_versions '-V'
++    extract_and_emit_compiler_versions '--version'
+ 
+     # Set alignment of fortran compiler
+     fcreal8="-s real64"
+@@ -2208,6 +2207,172 @@
+     fi
+     ;;
+ 
++#################### cray-shasta-gnu #######
++cray-shasta-gnu)
++    test -z "$pic" && pic="-fpic"
++    craympi='yes'
++    ld='ftn'
++    flibs_arch="-lgfortran -w"
++    flibsf_arch=
++    cc=cc
++    cflags="$pic -O3"
++    ambercflags=""
++    cplusplus=CC
++    cxxflags="$pic -O3"
++    ambercxxflags=""
++    fc=ftn
++    fflags="$pic -O3 -fallow-argument-mismatch"
++    # The -lstdc++ flag gives lots of duplicate symbol errors with cray
++    fc_cxx_link_flag="-lstdc++"
++    
++
++    if [ "$openmp" = 'yes' ]; then
++      omp_flag="-DOPENMP"
++      #flibs_arch="$flibs_arch -fopenmp"
++      #flibsf_arch="$flibsf_arch -fopenmp
++      cray_omp_flag=" -fopenmp "
++    elif [ "$mpi" = 'no' ]; then
++      #Note OMP is required for PMEMD MPI now so leave it on if mpi is true.
++      # OMP is enabled by default. Disable.
++      cray_omp_flag=""
++    fi
++
++    # If -noopt has been requested, force lack of optimisation;
++    # otherwise, use the default levels. Since cflags, cxxflags
++    # and fflags are used everywhere, and *optflags and
++    # *nooptflags are not (some parts of Amber and AmberTools use
++    # neither *optflags nor *nooptflags), we'll put -O0 in cflags
++    # and so forth instead.
++    # NOTE: In order for GNU-like defines to work (e.g.
++    #       -D_FILE_OFFSET_BITS etc.) cray compilers need '-h gnu'.
++    #       Also, the fortran compile requires '-emf' to force
++    #       the build of module files with all-lowercase names.
++    if [ "$optimise" = 'no' ]; then
++      cflags="$cflags -O0 $cray_omp_flag "
++      cnooptflags=""
++      coptflags=""
++      cxxflags="$cxxflags -O0 $cray_omp_flag "
++      cxxnooptflags=""
++      cxxoptflags="$pic"
++      fflags="$fflags -O0 $cray_omp_flag"
++      fnooptflags=""
++      foptflags="-ffixed-form"
++    else
++      # cray compilers have equivalent of -O3 on by default
++      cflags="$cflags $cray_omp_flag "
++      cnooptflags=""
++      coptflags=""
++      cxxflags="$cxxflags $cray_omp_flag "
++      cxxnooptflags=""
++      cxxoptflags="$pic"
++      fflags="$fflags $cray_omp_flag"
++      fnooptflags=""
++      foptflags="-ffixed-form"
++    fi
++
++    # Debugging options
++    if [ "$debug" = 'yes' ]; then
++      cflags="$cflags -g"
++      cxxflags="$cxxflags -g"
++      fflags="$fflags -g"
++    fi
++
++    extract_and_emit_compiler_versions '--version'
++
++    # Set alignment of fortran compiler
++    fcreal8="-s real64"
++
++    # For now, fftw3 is not compiled and rism is disabled.
++    if [ "$rism" != 'no' ]; then
++      echo "Error: RISM currently not built with cray compilers."
++      echo "       Please re-run configure with the '-nofftw3' flag to use this compiler:"
++      echo "            `mod_command_args '-rism' '-nofftw3'`"
++      exit 1
++    fi
++
++    if [ "$cygwin" = 'yes' -o "$windows" = 'yes' ]; then
++      echo "Error: cygwin not supported with cray compilers."
++      exit 1
++    fi
++
++    # The bundled NetCDF will not build with cray compilers. Require external.
++    if [ "$bintraj" = 'yes' -a -z "$netcdf_dir" ] ; then
++      echo "Error: Bundled NetCDF cannot be used with cray compilers."
++      echo "       Please re-run configure with the '--with-netcdf <DIR>' flag to"
++      echo "       specify system NetCDF to use. On cray systems you can usually"
++      echo "       load the system NetCDF with 'module load cray-netcdf' or"
++      echo "       'module load netcdf'."
++      exit 1
++    fi
++    # For some reason if static linking of NetCDF is not forced you end up
++    # with lots of missing symbols.
++    netcdfstatic='yes'
++
++    # Currently xleap on cray will not build due to errors like
++    #/usr/lib64/libX11.a(ClDisplay.o): In function `XCloseDisplay':
++    #/usr/src/packages/BUILD/libX11-1.1.5/src/ClDisplay.c:78: undefined reference to `xcb_disconnect'
++    if [ "$noX11" = 'false' ] ; then
++      echo "Error: Cannot build XLEaP with cray compilers."
++      echo "       Please re-run configure with the '-noX11' flag to use this compiler."
++      exit 1
++    fi
++
++    freeformat_flag="-ffree-form"
++
++    #PMEMD Specifics
++    # PMEMD right now with cray requires external FFTW3 library
++    cat > conftest.f90 <<EOF
++program conftest
++include 'fftw3.f'
++       write(*,'(a)') 'gotcha!'
++end program conftest
++EOF
++    echo ""
++    echo "Checking for external FFTW3 library (required for PMEMD w/ $compiler compilers)"
++    $fc $fflags $fnooptflags -o conftest$suffix conftest.f90
++    echo "     $fc $fflags $fnooptflags -o conftest$suffix conftest.f90"
++    ./conftest$suffix | grep "gotcha!" > /dev/null
++    status=$?
++    if [ $status -gt 0 ]; then
++      echo "Error: FFTW3 library not found."
++      echo "       Ensure FFTW3 library can be found by your compiler."
++      echo "       On cray systems this can usually be done with 'module load fftw'"
++      exit 1
++    fi
++    echo "OK"
++    /bin/rm -f conftest.f90 conftest$objsuffix conftest$suffix
++
++    #pmemd_fpp_flags='-DPUBFFT'
++    pmemd_fpp_flags='-DFFTW_FFT'
++    pmemd_foptflags="$foptflags $cray_omp_flag"
++    pmemd_coptflags="$coptflags  $cray_omp_flag"
++
++    if [ "$debug" = 'yes' ]; then
++        pmemd_foptflags="-g $pmemd_foptflags"
++        pmemd_coptflags="-g $pmemd_coptflags"
++    fi
++
++    #CUDA Specifics
++    if [ "$cuda" = 'yes' ]; then
++      pmemd_cu_includes='-I$(CUDA_HOME)/include -IB40C'
++      pmemd_cu_defines='-DCUDA'
++      pmemd_cu_libs="./cuda/cuda.a -L\$(CUDA_HOME)/lib64 -L\$(CUDA_HOME)/lib -lcurand -lcufft -lcudart $fc_cxx_link_flag"
++      pbsa_cu_libs="-L\$(CUDA_HOME)/lib64 -L\$(CUDA_HOME)/lib -lcublas -lcusparse -lcudart $fc_cxx_link_flag"
++      if [ "$optimise" = 'no' ]; then
++        nvcc="$nvcc -use_fast_math -O0 "
++      else
++        nvcc="$nvcc -use_fast_math -O3 "
++      fi
++      if [ "$mpi" = 'yes' ]; then
++        mpi_inc=`(mpicc -show 2>&1) | awk 'BEGIN{i=0} {while (i < NF) {if ( substr($i, 1, 2) == "-I" ) {printf("%s ", $i);}; i++;}}'`
++        pmemd_cu_includes="$pmemd_cu_includes $mpi_inc"
++        pmemd_cu_defines="$pmemd_cu_defines -DMPI -DMPICH_IGNORE_CXX_SEEK"
++        pmemd_coptflags="$coptflags -DMPICH_IGNORE_CXX_SEEK"
++      fi
++    fi
++    ;;
++
++
+ #################### clang ####
+ clang)
+     if [ "$intelmpi" = 'yes' ]; then
+@@ -2324,7 +2489,7 @@
+       fi
+     fi
+ 
+-    extract_and_emit_compiler_versions "-v"
++    extract_and_emit_compiler_versions "--version"
+     ;;
+ #################### unknown choice #######
+ *)
+@@ -2534,7 +2699,9 @@
+ 
+ echo ""
+ echo "Testing the $cc compiler:"
+-echo "     $cc $cflags $cnooptflags -o testp$suffix testp.c"
++echo "     $cc with testp$suffix testp.c"
++echo "     cflags $cflags "
++echo "     nooptflags $cnooptflags "
+ $cc $cflags $cnooptflags -o testp$suffix testp.c
+ $wine ./testp$suffix | grep "testing a C program" > /dev/null
+ status=$?
+@@ -3183,6 +3350,9 @@
+     if [ "$intelmpi" = "yes" ]; then
+         mpicc="MPICC=mpiicc"
+     fi
++    if [ "$craympi" = "yes" ]; then
++        mpicc="MPICC=cc"
++    fi
+     if [ "$debug" = "yes" ]; then
+         enable_debug="--enable-debug=yes --enable-debug-malloc=yes --enable-debug-alignment=yes"
+     fi
+@@ -3381,6 +3551,10 @@
+       if [ -z "$MPICC" ]; then cc="mpiicc"; else cc="$MPICC"; fi
+       if [ -z "$MPICXX" ]; then cplusplus="mpiicpc"; else cplusplus="$MPICXX"; fi
+       if [ -z "$MPIF90" ]; then fc="mpiifort"; else fc="$MPIF90"; fi
++  elif [ "$craympi" = 'yes' ]; then
++      if [ -z "$MPICC" ]; then cc="cc"; else cc="$MPICC"; fi
++      if [ -z "$MPICXX" ]; then cplusplus="CC"; else cplusplus="$MPICXX"; fi
++      if [ -z "$MPIF90" ]; then fc="ftn"; else fc="$MPIF90"; fi
+   else
+       if [ -z "$MPICC" ]; then cc="mpicc"; else cc="$MPICC"; fi
+       if [ -z "$MPICXX" ]; then cplusplus="mpicxx"; else cplusplus="$MPICXX"; fi

--- a/setonix/repo_setonix/packages/amber/ambertools_configure2_cray_shasta.patch
+++ b/setonix/repo_setonix/packages/amber/ambertools_configure2_cray_shasta.patch
@@ -1,0 +1,514 @@
+--- a/ambertools_tmpdir/AmberTools/src/configure2	2020-04-28 09:19:43.000000000 +0800
++++ b/ambertools_tmpdir/AmberTools/src/configure2	2022-02-14 11:13:05.000000000 +0800
+@@ -11,7 +11,7 @@
+ cat<<EOD
+ Usage: ./configure [flags] compiler
+ 
+-    where compiler is one of: [[ gnu, intel, pgi, clang, or cray ]]
++    where compiler is one of: [[ gnu, intel, pgi, clang, or cray, cray-shasta-gnu, cray-shasta-cray, cray-shasta-aocc ]]
+ 
+                               COMPILERS
+                  -------------------------------------------------------------
+@@ -191,6 +191,12 @@
+                      have both C and Fortran interfaces.  Required for Cray
+                      compilers.
+ 
++      --with-netcdf-c </path/to/netcdf-c>
++                     Specify an external NetCDF C build to use. 
++
++      --with-netcdf-fortran </path/to/netcdf-fortran>
++                     Specify an external NetCDF Fortran build to use. 
++
+       -netcdfstatic  Force static linking to the external NetCDF specified via
+                      the --with-netcdf option.
+ 
+@@ -488,6 +494,7 @@
+ has_boost=''
+ installtype='serial'
+ intelmpi='no'
++craympi='no'
+ is_mac='no'
+ ldflags=''
+ ld='ld '
+@@ -509,6 +516,8 @@
+ mpinab=''
+ mpi='no'
+ netcdf_dir=''
++netcdfc_dir=''
++netcdff_dir=''
+ netcdf_flag=''
+ netcdfstatic='no'
+ pmemd_gem='no'
+@@ -607,6 +616,8 @@
+         --skip-python)    skippython='yes' ;;
+         --with-python)    shift; python="$1";;
+         --with-netcdf)    shift; netcdf_dir="$1";;
++        --with-netcdf-c)  shift; netcdfc_dir="$1";;
++        --with-netcdf-fortran)  shift; netcdff_dir="$1";;
+         --with-pnetcdf)   shift; pnetcdf_dir="$1" ;;
+         --python-install) shift; python_install="$1";;
+         --miniconda)      answer='y';;
+@@ -1250,24 +1261,40 @@
+     sm30flags='-gencode arch=compute_30,code=sm_30'
+ 
+     cudaversion=`$nvcc --version | grep 'release' | cut -d' ' -f5 | cut -d',' -f1`
+-    if [ "$cudaversion" = "9.0" -o "$cudaversion" = "9.1" -o "$cudaversion" = "9.2" -o \
+-         "$cudaversion" = "10.0" -o "$cudaversion" = "10.1" -o "$cudaversion" = "10.2" ]; then
++    if [ "$cudaversion" = "11.0" -o "$cudaversion" = "11.1" ]; then
++      # Implement the standard, not warp synchronous, compilation
++      sm80flags='-gencode arch=compute_80,code=sm_80'
++      sm75flags='-gencode arch=compute_75,code=sm_75'
++      sm70flags='-gencode arch=compute_70,code=sm_70'
++      echo "CUDA Version $cudaversion detected"
++      echo "Configuring for SM5.0, SM5.2, SM5.3, SM6.0, SM6.1, SM7.0, SM7.5 and SM8.0"
++      nvccflags="$sm50flags $sm52flags $sm53flags $sm60flags $sm61flags $sm70flags $sm75flags $sm80flags -Wno-deprecated-declarations"
++
++    elif [ "$cudaversion" = "10.0" -o "$cudaversion" = "10.1" -o "$cudaversion" = "10.2" ]; then
++      echo "CUDA Version $cudaversion detected"
++      echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2, SM5.3, SM6.0, SM6.1, SM7.0 and SM7.5"
++      nvccflags="$sm30flags $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags $sm70flags $sm75flags -Wno-deprecated-declarations"
++
++    elif [ "$cudaversion" = "9.0" -o "$cudaversion" = "9.1" -o "$cudaversion" = "9.2" ]; then
+       echo "CUDA Version $cudaversion detected"
+       echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2, SM5.3, SM6.0, SM6.1 and SM7.0"
+       nvccflags="$sm30flags $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags $sm70flags -Wno-deprecated-declarations"
++
+     elif [ "$cudaversion" = "8.0" ]; then
+       echo "CUDA Version $cudaversion detected"
+       echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2, SM5.3, SM6.0 and SM6.1"
+       echo "BE AWARE: CUDA 8.0 does not support V100, GV100, Titan-V or later GPUs."
+       nvccflags="$sm30flags $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags"
++
+     elif [ "$cudaversion" = "7.5" ]; then
+       echo "CUDA Version $cudaversion detected"
+       echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2 and SM5.3"
+       echo "BE AWARE: CUDA 7.5 does not support GTX-1080, Titan-XP, DGX-1, V100 or other Pascal/Volta based or later GPUs."
+       nvccflags="$sm30flags  $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags"
++
+     else
+       echo "Error: Unsupported CUDA version $cudaversion detected."
+-      echo "       Amber requires CUDA version 7.5, 8.0, 9.0-9.2, or 10.0-10.2"
++      echo "       Amber requires CUDA version 7.5, 8.0, 9.0-9.2, 10.0-10.2 or 11.0-11.1"
+       exit 1
+     fi
+     nvcc="$nvcc $nvccflags"
+@@ -1359,7 +1386,7 @@
+       fflags="$fflags -g"
+     fi
+ 
+-    extract_and_emit_compiler_versions '-v'
++    extract_and_emit_compiler_versions '--version'
+ 
+     if [ $cc_version_major -ge 4 -a $cc_version_minor -ge 2 -a "$optimise" = "yes" ]; then
+       if [ $sse = 'yes' ]; then
+@@ -1574,7 +1601,7 @@
+         fflags="$fflags -g -debug all"
+     fi
+ 
+-    extract_and_emit_compiler_versions '-v'
++    extract_and_emit_compiler_versions '--version'
+ 
+     # Intel 18.0.x not ready for prime time; srb mar 26, 2018; see
+     # [AMBER-Developers] Intel compilers and Amber18
+@@ -2028,21 +2055,18 @@
+ #################### cray #######
+ cray)
+     test -z "$pic" && pic="-fpic"
+-    if [ "$intelmpi" = 'yes' ]; then
+-      echo "Intel MPI requires the intel compilers."
+-      exit 1
+-    fi
++    craympi='yes'
+     ld='ftn'
+     flibs_arch=""
+     flibsf_arch=
+     cc=cc
+-    cflags="$pic"
++    cflags="$pic -O3"
+     ambercflags=""
+     cplusplus=CC
+-    cxxflags="$pic"
++    cxxflags="$pic -O3"
+     ambercxxflags=""
+     fc=ftn
+-    fflags="$pic"
++    fflags="$pic -O3"
+     # The -lstdc++ flag gives lots of duplicate symbol errors with cray
+     fc_cxx_link_flag=""
+ 
+@@ -2067,6 +2091,7 @@
+     #       -D_FILE_OFFSET_BITS etc.) cray compilers need '-h gnu'.
+     #       Also, the fortran compile requires '-emf' to force
+     #       the build of module files with all-lowercase names.
++    # old cray compilers
+     if [ "$optimise" = 'no' ]; then
+       cflags="$cflags -O0 $cray_omp_flag -h gnu"
+       cnooptflags=""
+@@ -2097,7 +2122,7 @@
+       fflags="$fflags -g"
+     fi
+ 
+-    extract_and_emit_compiler_versions '-V'
++    extract_and_emit_compiler_versions '--version'
+ 
+     # Set alignment of fortran compiler
+     fcreal8="-s real64"
+@@ -2192,6 +2217,173 @@
+     fi
+     ;;
+ 
++#################### cray-shasta-gnu #######
++cray-shasta-gnu)
++    test -z "$pic" && pic="-fpic"
++    craympi='yes'
++    ld='ftn'
++    flibs_arch="-lgfortran -w"
++    flibsf_arch=
++    cc=cc
++    cflags="$pic -O3"
++    ambercflags=""
++    cplusplus=CC
++    cxxflags="$pic -O3"
++    ambercxxflags=""
++    fc=ftn
++    fflags="$pic -O3 -fallow-argument-mismatch"
++    # The -lstdc++ flag gives lots of duplicate symbol errors with cray
++    fc_cxx_link_flag="-lstdc++"
++    
++
++    if [ "$openmp" = 'yes' ]; then
++      omp_flag="-DOPENMP"
++      #flibs_arch="$flibs_arch -fopenmp"
++      #flibsf_arch="$flibsf_arch -fopenmp
++      cray_omp_flag=" -fopenmp "
++    elif [ "$mpi" = 'no' ]; then
++      #Note OMP is required for PMEMD MPI now so leave it on if mpi is true.
++      # OMP is enabled by default. Disable.
++      cray_omp_flag=""
++    fi
++
++    # If -noopt has been requested, force lack of optimisation;
++    # otherwise, use the default levels. Since cflags, cxxflags
++    # and fflags are used everywhere, and *optflags and
++    # *nooptflags are not (some parts of Amber and AmberTools use
++    # neither *optflags nor *nooptflags), we'll put -O0 in cflags
++    # and so forth instead.
++    # NOTE: In order for GNU-like defines to work (e.g.
++    #       -D_FILE_OFFSET_BITS etc.) cray compilers need '-h gnu'.
++    #       Also, the fortran compile requires '-emf' to force
++    #       the build of module files with all-lowercase names.
++    if [ "$optimise" = 'no' ]; then
++      cflags="$cflags -O0 $cray_omp_flag "
++      cnooptflags=""
++      coptflags=""
++      cxxflags="$cxxflags -O0 $cray_omp_flag "
++      cxxnooptflags=""
++      cxxoptflags="$pic"
++      fflags="$fflags -O0 $cray_omp_flag"
++      fnooptflags=""
++      foptflags="-ffixed-form"
++    else
++      # cray compilers have equivalent of -O3 on by default
++      cflags="$cflags $cray_omp_flag "
++      cnooptflags=""
++      coptflags=""
++      cxxflags="$cxxflags $cray_omp_flag "
++      cxxnooptflags=""
++      cxxoptflags="$pic"
++      fflags="$fflags $cray_omp_flag"
++      fnooptflags=""
++      foptflags="-ffixed-form"
++    fi
++
++    # Debugging options
++    if [ "$debug" = 'yes' ]; then
++      cflags="$cflags -g"
++      cxxflags="$cxxflags -g"
++      fflags="$fflags -g"
++    fi
++
++    extract_and_emit_compiler_versions '--version'
++
++    # Set alignment of fortran compiler
++    fcreal8="-s real64"
++
++    # For now, fftw3 is not compiled and rism is disabled.
++    # if [ "$rism" != 'no' ]; then
++    #   echo "Error: RISM currently not built with cray compilers."
++    #   echo "       Please re-run configure with the '-nofftw3' flag to use this compiler:"
++    #   echo "            `mod_command_args '-rism' '-nofftw3'`"
++    #   exit 1
++    # fi
++
++    if [ "$cygwin" = 'yes' -o "$windows" = 'yes' ]; then
++      echo "Error: cygwin not supported with cray compilers."
++      exit 1
++    fi
++
++    # The bundled NetCDF will not build with cray compilers. Require external.
++    if [ "$bintraj" = 'yes' -a -z "$netcdfc_dir" -a -z "$netcdff_dir" ] ; then
++      echo "Error: Bundled NetCDF cannot be used with cray compilers."
++      echo "       Please re-run configure with the '--with-netcdf-c <DIR>' flag to"
++      echo "       specify system NetCDF C to use. "
++      echo "       Please re-run configure with the '--with-netcdf-fortran <DIR>' flag to"
++      echo "       specify system NetCDF Fortran to use. "
++      exit 1
++    fi
++    # For some reason if static linking of NetCDF is not forced you end up
++    # with lots of missing symbols.
++    # looks like netcdfstatic is also used to indicate use external netcdf
++    #netcdfstatic='yes'
++
++    # Currently xleap on cray will not build due to errors like
++    #/usr/lib64/libX11.a(ClDisplay.o): In function `XCloseDisplay':
++    #/usr/src/packages/BUILD/libX11-1.1.5/src/ClDisplay.c:78: undefined reference to `xcb_disconnect'
++    if [ "$noX11" = 'false' ] ; then
++      echo "Error: Cannot build XLEaP with cray compilers."
++      echo "       Please re-run configure with the '-noX11' flag to use this compiler."
++      exit 1
++    fi
++
++    freeformat_flag="-ffree-form"
++
++#     #PMEMD Specifics
++#     # PMEMD right now with cray requires external FFTW3 library
++#     cat > conftest.f90 <<EOF
++# program conftest
++# include 'fftw3.f'
++#        write(*,'(a)') 'gotcha!'
++# end program conftest
++# EOF
++#     echo ""
++#     echo "Checking for external FFTW3 library (required for PMEMD w/ $compiler compilers)"
++#     $fc $fflags $fnooptflags -o conftest$suffix conftest.f90
++#     echo "     $fc $fflags $fnooptflags -o conftest$suffix conftest.f90"
++#     ./conftest$suffix | grep "gotcha!" > /dev/null
++#     status=$?
++#     if [ $status -gt 0 ]; then
++#       echo "Error: FFTW3 library not found."
++#       echo "       Ensure FFTW3 library can be found by your compiler."
++#       echo "       On cray systems this can usually be done with 'module load fftw'"
++#       exit 1
++#     fi
++#     echo "OK"
++#     /bin/rm -f conftest.f90 conftest$objsuffix conftest$suffix
++
++    #pmemd_fpp_flags='-DPUBFFT'
++    pmemd_fpp_flags='-DFFTW_FFT'
++    pmemd_foptflags="$foptflags $cray_omp_flag"
++    pmemd_coptflags="$coptflags  $cray_omp_flag"
++
++    if [ "$debug" = 'yes' ]; then
++        pmemd_foptflags="-g $pmemd_foptflags"
++        pmemd_coptflags="-g $pmemd_coptflags"
++    fi
++
++    #CUDA Specifics
++    if [ "$cuda" = 'yes' ]; then
++      pmemd_cu_includes='-I$(CUDA_HOME)/include -IB40C'
++      pmemd_cu_defines='-DCUDA'
++      pmemd_cu_libs="./cuda/cuda.a -L\$(CUDA_HOME)/lib64 -L\$(CUDA_HOME)/lib -lcurand -lcufft -lcudart $fc_cxx_link_flag"
++      pbsa_cu_libs="-L\$(CUDA_HOME)/lib64 -L\$(CUDA_HOME)/lib -lcublas -lcusparse -lcudart $fc_cxx_link_flag"
++      if [ "$optimise" = 'no' ]; then
++        nvcc="$nvcc -use_fast_math -O0 "
++      else
++        nvcc="$nvcc -use_fast_math -O3 "
++      fi
++      if [ "$mpi" = 'yes' ]; then
++        mpi_inc=`(mpicc -show 2>&1) | awk 'BEGIN{i=0} {while (i < NF) {if ( substr($i, 1, 2) == "-I" ) {printf("%s ", $i);}; i++;}}'`
++        pmemd_cu_includes="$pmemd_cu_includes $mpi_inc"
++        pmemd_cu_defines="$pmemd_cu_defines -DMPI -DMPICH_IGNORE_CXX_SEEK"
++        pmemd_coptflags="$coptflags -DMPICH_IGNORE_CXX_SEEK"
++      fi
++    fi
++    ;;
++
++
+ #################### clang ####
+ clang)
+     if [ "$intelmpi" = 'yes' ]; then
+@@ -2308,7 +2500,7 @@
+       fi
+     fi
+ 
+-    extract_and_emit_compiler_versions "-v"
++    extract_and_emit_compiler_versions "--version"
+     ;;
+ #################### unknown choice #######
+ *)
+@@ -2518,7 +2710,9 @@
+ 
+ echo ""
+ echo "Testing the $cc compiler:"
+-echo "     $cc $cflags $cnooptflags -o testp$suffix testp.c"
++echo "     $cc with testp$suffix testp.c"
++echo "     cflags $cflags "
++echo "     nooptflags $cnooptflags "
+ $cc $cflags $cnooptflags -o testp$suffix testp.c
+ $wine ./testp$suffix | grep "testing a C program" > /dev/null
+ status=$?
+@@ -2735,11 +2929,12 @@
+   cflags="$cflags -DBINTRAJ"
+   pmemd_coptflags="$pmemd_coptflags -DBINTRAJ"
+   fppflags="$fppflags -DBINTRAJ"
+-  if [ "$netcdf_dir" = '' ]; then
++  if [ "$netcdf_dir" = '' -a "$netcdfc_dir" = '' -a "$netcdff_dir" = '' ]; then
+     # Use bundled NetCDF library.
+     if [ "$netcdfstatic" != 'no' ] ; then
+       echo "Error: -netcdfstatic requires an external NetCDF specified via"
+       echo "       the --with-netcdf option."
++      echo "       Or --with-netcdf-c and --with-netcdf-fortran option."
+       exit 1
+     fi
+     # Initially set full paths for use with test_netcdf_compile.
+@@ -2877,38 +3072,77 @@
+     netcdf="\$(INCDIR)/netcdf.mod"
+   else
+     # A NetCDF directory was specified. Check that library exists and compiles
+-    printf "\tUsing external NetCDF in '$netcdf_dir'\n"
+-    netcdfinc="-I"$netcdf_dir"/include"
+-    if [ "${netcdf_dir}" != '/usr' -a "$netcdf_dir" != '/usr/' ]; then
+-        netcdf_flag="-L${netcdf_dir}/lib $netcdf_flag"
+-    fi
+-    netcdf=$netcdf_dir"/include/netcdf.mod"
+-    if [ "$netcdfstatic" = 'no' ] ; then
+-      if [ "${netcdf_dir}" != '/usr' -a "${netcdf_dir}" != '/usr/' ]; then
+-          netcdfflagc="-L${netcdf_dir}/lib -lnetcdf"
+-          netcdfflagf="-L${netcdf_dir}/lib -lnetcdff -lnetcdf"
+-      else
+-          netcdfflagc="-lnetcdf"
+-          netcdfflagf="-lnetcdff -lnetcdf"
+-      fi
+-    else # Force static linking to netcdf
+-      printf "\tForcing static linking to external NetCDF\n"
+-      netcdfflagc=$netcdf_dir"/lib/libnetcdf.a"
+-      if [ ! -e "$netcdfflagc" ]; then
+-        echo "Error: '$netcdfflagc' not found."
+-        exit 1
++    printf "\tUsing external NetCDF in '$netcdf_dir' or "
++    printf "NetCDF-C '$netcdfc_dir' with NetCDF-Fortran '$netcdff_dir' \n"
++
++    # if individual netcdfc and fortran passed 
++    if [ "$netcdf_dir" = '' ]; then 
++      netcdfinc="-I"$netcdfc_dir"/include "
++      netcdfinc+="-I"$netcdff_dir"/include"
++      # netcdf c and fortran directories passed
++      if [ "${netcdfc_dir}" != '/usr' -a "$netcdfc_dir" != '/usr/' ]; then
++          netcdf_flag="-L${netcdfc_dir}/lib $netcdf_flag"
++      fi
++      if [ "${netcdff_dir}" != '/usr' -a "$netcdff_dir" != '/usr/' ]; then
++          netcdf_flag="-L${netcdff_dir}/lib $netcdf_flag"
++      fi
++      netcdf=$netcdff_dir"/include/netcdf.mod"
++      if [ "$netcdfstatic" = 'no' ] ; then
++        if [ "${netcdfc_dir}" != '/usr' -a "${netcdfc_dir}" != '/usr/' ]; then
++            netcdfflagc="-L${netcdfc_dir}/lib -lnetcdf"
++            netcdfflagf="-L${netcdff_dir}/lib -lnetcdff -lnetcdf"
++        else
++            netcdfflagc="-lnetcdf"
++            netcdfflagf="-lnetcdff -lnetcdf"
++        fi
++      else # Force static linking to netcdf
++        printf "\tForcing static linking to external NetCDF\n"
++        netcdfflagc=$netcdfc_dir"/lib/libnetcdf.a"
++        if [ ! -e "$netcdfflagc" ]; then
++          echo "Error: '$netcdfflagc' not found."
++          exit 1
++        fi
++        netcdfflagf=$netcdff_dir"/lib/libnetcdff.a"
++        if [ ! -e "$netcdfflagf" ]; then
++          echo "Error: '$netcdfflagf' not found."
++          exit 1
++        fi
++        netcdfflagf="$netcdfflagf $netcdfflagc"
+       fi
+-      netcdfflagf=$netcdf_dir"/lib/libnetcdff.a"
+-      if [ ! -e "$netcdfflagf" ]; then
+-        echo "Error: '$netcdfflagf' not found."
+-        exit 1
++    else 
++      netcdfinc="-I"$netcdf_dir"/include"
++      if [ "${netcdf_dir}" != '/usr' -a "$netcdf_dir" != '/usr/' ]; then
++          netcdf_flag="-L${netcdf_dir}/lib $netcdf_flag"
++      fi
++      netcdf=$netcdf_dir"/include/netcdf.mod"
++      if [ "$netcdfstatic" = 'no' ] ; then
++        if [ "${netcdf_dir}" != '/usr' -a "${netcdf_dir}" != '/usr/' ]; then
++            netcdfflagc="-L${netcdf_dir}/lib -lnetcdf"
++            netcdfflagf="-L${netcdf_dir}/lib -lnetcdff -lnetcdf"
++        else
++            netcdfflagc="-lnetcdf"
++            netcdfflagf="-lnetcdff -lnetcdf"
++        fi
++      else # Force static linking to netcdf
++        printf "\tForcing static linking to external NetCDF\n"
++        netcdfflagc=$netcdf_dir"/lib/libnetcdf.a"
++        if [ ! -e "$netcdfflagc" ]; then
++          echo "Error: '$netcdfflagc' not found."
++          exit 1
++        fi
++        netcdfflagf=$netcdf_dir"/lib/libnetcdff.a"
++        if [ ! -e "$netcdfflagf" ]; then
++          echo "Error: '$netcdfflagf' not found."
++          exit 1
++        fi
++        netcdfflagf="$netcdfflagf $netcdfflagc"
+       fi
+-      netcdfflagf="$netcdfflagf $netcdfflagc"
+     fi
+     # Test netcdf compilation
+     test_netcdf_compile verbose
+     if [ $? -gt 0 ]; then
+-      echo "Error: Could not compile using NetCDF in '$netcdf_dir'"
++      echo "Error: Could not compile using NetCDF in '$netcdf_dir' or "
++      echo "NetCDF-C in '$netcdfc_dir' and NetCDF-Fortran in '$netcdff_dir'"
+       exit 1
+     fi
+     echo "OK"
+@@ -3167,6 +3401,9 @@
+     if [ "$intelmpi" = "yes" ]; then
+         mpicc="MPICC=mpiicc"
+     fi
++    if [ "$craympi" = "yes" ]; then
++        mpicc="MPICC=cc"
++    fi
+     if [ "$debug" = "yes" ]; then
+         enable_debug="--enable-debug=yes --enable-debug-malloc=yes --enable-debug-alignment=yes"
+     fi
+@@ -3365,6 +3602,10 @@
+       if [ -z "$MPICC" ]; then cc="mpiicc"; else cc="$MPICC"; fi
+       if [ -z "$MPICXX" ]; then cplusplus="mpiicpc"; else cplusplus="$MPICXX"; fi
+       if [ -z "$MPIF90" ]; then fc="mpiifort"; else fc="$MPIF90"; fi
++  elif [ "$craympi" = 'yes' ]; then
++      if [ -z "$MPICC" ]; then cc="cc"; else cc="$MPICC"; fi
++      if [ -z "$MPICXX" ]; then cplusplus="CC"; else cplusplus="$MPICXX"; fi
++      if [ -z "$MPIF90" ]; then fc="ftn"; else fc="$MPIF90"; fi
+   else
+       if [ -z "$MPICC" ]; then cc="mpicc"; else cc="$MPICC"; fi
+       if [ -z "$MPICXX" ]; then cplusplus="mpicxx"; else cplusplus="$MPICXX"; fi
+@@ -3558,6 +3799,8 @@
+ fi
+ if [ ! -z "$netcdf_dir" ] ; then
+   CPPTRAJOPTS="$CPPTRAJOPTS --with-netcdf=$netcdf_dir"
++elif [ ! -z "$netcdfc_dir" ]; then 
++  CPPTRAJOPTS="$CPPTRAJOPTS --with-netcdf-c=$netcdfc_dir --with-netcdf-fortran=$netcdff_dir"
+ else
+   CPPTRAJOPTS="$CPPTRAJOPTS --with-netcdf=$CPPTRAJHOME"
+ fi
+@@ -3777,6 +4020,16 @@
+   echo "Warning: Currently PBSA and related programs (MMPBSA, Sander, etc)"
+   echo "         do not build with cray compilers."
+   if [ "$installtype" = 'serial' ] ; then
++    installtype='cray_serial'
++  elif [ "$installtype" = 'parallel' ] ; then
++    installtype='cray_parallel'
++  elif [ "$installtype" = 'openmp' ] ; then
++    installtype='cray_openmp'
++  fi
++elif [ "$compiler" = 'cray-shasta-gnu' ] ; then
++  echo "Warning: Currently PBSA and related programs (MMPBSA, Sander, etc)"
++  echo "         do not build with cray compilers."
++  if [ "$installtype" = 'serial' ] ; then
+     installtype='cray_serial'
+   elif [ "$installtype" = 'parallel' ] ; then
+     installtype='cray_parallel'

--- a/setonix/repo_setonix/packages/amber/ambertools_configure2_for_netcdf.patch
+++ b/setonix/repo_setonix/packages/amber/ambertools_configure2_for_netcdf.patch
@@ -1,0 +1,225 @@
+--- /home/pelahi/tmp/build_stage/spack-stage-amber-20-32owemucowv2n7wep65uirrn6qcuwvcz/spack-src/AmberTools/src/configure2	2022-02-11 16:22:21.000000000 +0800
++++ /home/pelahi/amber20_src/AmberTools/src/configure2	2022-02-11 16:35:52.000000000 +0800
+@@ -191,6 +191,12 @@
+                      have both C and Fortran interfaces.  Required for Cray
+                      compilers.
+ 
++      --with-netcdf-c </path/to/netcdf-c>
++                     Specify an external NetCDF C build to use. 
++
++      --with-netcdf-fortran </path/to/netcdf-fortran>
++                     Specify an external NetCDF Fortran build to use. 
++
+       -netcdfstatic  Force static linking to the external NetCDF specified via
+                      the --with-netcdf option.
+ 
+@@ -510,6 +516,8 @@
+ mpinab=''
+ mpi='no'
+ netcdf_dir=''
++netcdfc_dir=''
++netcdff_dir=''
+ netcdf_flag=''
+ netcdfstatic='no'
+ pmemd_gem='no'
+@@ -608,6 +616,8 @@
+         --skip-python)    skippython='yes' ;;
+         --with-python)    shift; python="$1";;
+         --with-netcdf)    shift; netcdf_dir="$1";;
++        --with-netcdf-c)  shift; netcdfc_dir="$1";;
++        --with-netcdf-fortran)  shift; netcdff_dir="$1";;
+         --with-pnetcdf)   shift; pnetcdf_dir="$1" ;;
+         --python-install) shift; python_install="$1";;
+         --miniconda)      answer='y';;
+@@ -1251,24 +1261,40 @@
+     sm30flags='-gencode arch=compute_30,code=sm_30'
+ 
+     cudaversion=`$nvcc --version | grep 'release' | cut -d' ' -f5 | cut -d',' -f1`
+-    if [ "$cudaversion" = "9.0" -o "$cudaversion" = "9.1" -o "$cudaversion" = "9.2" -o \
+-         "$cudaversion" = "10.0" -o "$cudaversion" = "10.1" -o "$cudaversion" = "10.2" ]; then
++    if [ "$cudaversion" = "11.0" -o "$cudaversion" = "11.1" ]; then
++      # Implement the standard, not warp synchronous, compilation
++      sm80flags='-gencode arch=compute_80,code=sm_80'
++      sm75flags='-gencode arch=compute_75,code=sm_75'
++      sm70flags='-gencode arch=compute_70,code=sm_70'
++      echo "CUDA Version $cudaversion detected"
++      echo "Configuring for SM5.0, SM5.2, SM5.3, SM6.0, SM6.1, SM7.0, SM7.5 and SM8.0"
++      nvccflags="$sm50flags $sm52flags $sm53flags $sm60flags $sm61flags $sm70flags $sm75flags $sm80flags -Wno-deprecated-declarations"
++
++    elif [ "$cudaversion" = "10.0" -o "$cudaversion" = "10.1" -o "$cudaversion" = "10.2" ]; then
++      echo "CUDA Version $cudaversion detected"
++      echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2, SM5.3, SM6.0, SM6.1, SM7.0 and SM7.5"
++      nvccflags="$sm30flags $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags $sm70flags $sm75flags -Wno-deprecated-declarations"
++
++    elif [ "$cudaversion" = "9.0" -o "$cudaversion" = "9.1" -o "$cudaversion" = "9.2" ]; then
+       echo "CUDA Version $cudaversion detected"
+       echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2, SM5.3, SM6.0, SM6.1 and SM7.0"
+       nvccflags="$sm30flags $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags $sm70flags -Wno-deprecated-declarations"
++
+     elif [ "$cudaversion" = "8.0" ]; then
+       echo "CUDA Version $cudaversion detected"
+       echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2, SM5.3, SM6.0 and SM6.1"
+       echo "BE AWARE: CUDA 8.0 does not support V100, GV100, Titan-V or later GPUs."
+       nvccflags="$sm30flags $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags $sm60flags $sm61flags"
++
+     elif [ "$cudaversion" = "7.5" ]; then
+       echo "CUDA Version $cudaversion detected"
+       echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM5.2 and SM5.3"
+       echo "BE AWARE: CUDA 7.5 does not support GTX-1080, Titan-XP, DGX-1, V100 or other Pascal/Volta based or later GPUs."
+       nvccflags="$sm30flags  $sm35flags $sm37flags $sm50flags $sm52flags $sm53flags"
++
+     else
+       echo "Error: Unsupported CUDA version $cudaversion detected."
+-      echo "       Amber requires CUDA version 7.5, 8.0, 9.0-9.2, or 10.0-10.2"
++      echo "       Amber requires CUDA version 7.5, 8.0, 9.0-9.2, 10.0-10.2 or 11.0-11.1"
+       exit 1
+     fi
+     nvcc="$nvcc $nvccflags"
+@@ -2280,16 +2306,17 @@
+     fi
+ 
+     # The bundled NetCDF will not build with cray compilers. Require external.
+-    if [ "$bintraj" = 'yes' -a -z "$netcdf_dir" ] ; then
++    if [ "$bintraj" = 'yes' -a -z "$netcdfc_dir" -a -z "$netcdff_dir" ] ; then
+       echo "Error: Bundled NetCDF cannot be used with cray compilers."
+-      echo "       Please re-run configure with the '--with-netcdf <DIR>' flag to"
+-      echo "       specify system NetCDF to use. On cray systems you can usually"
+-      echo "       load the system NetCDF with 'module load cray-netcdf' or"
+-      echo "       'module load netcdf'."
++      echo "       Please re-run configure with the '--with-netcdf-c <DIR>' flag to"
++      echo "       specify system NetCDF C to use. "
++      echo "       Please re-run configure with the '--with-netcdf-fortran <DIR>' flag to"
++      echo "       specify system NetCDF Fortran to use. "
+       exit 1
+     fi
+     # For some reason if static linking of NetCDF is not forced you end up
+     # with lots of missing symbols.
++    # looks like netcdfstatic is also used to indicate use external netcdf
+     netcdfstatic='yes'
+ 
+     # Currently xleap on cray will not build due to errors like
+@@ -2902,11 +2929,12 @@
+   cflags="$cflags -DBINTRAJ"
+   pmemd_coptflags="$pmemd_coptflags -DBINTRAJ"
+   fppflags="$fppflags -DBINTRAJ"
+-  if [ "$netcdf_dir" = '' ]; then
++  if [ "$netcdf_dir" = '' -a "$netcdfc_dir" = '' -a "$netcdff_dir" = '' ]; then
+     # Use bundled NetCDF library.
+     if [ "$netcdfstatic" != 'no' ] ; then
+       echo "Error: -netcdfstatic requires an external NetCDF specified via"
+       echo "       the --with-netcdf option."
++      echo "       Or --with-netcdf-c and --with-netcdf-fortran option."
+       exit 1
+     fi
+     # Initially set full paths for use with test_netcdf_compile.
+@@ -3044,38 +3072,75 @@
+     netcdf="\$(INCDIR)/netcdf.mod"
+   else
+     # A NetCDF directory was specified. Check that library exists and compiles
+-    printf "\tUsing external NetCDF in '$netcdf_dir'\n"
+-    netcdfinc="-I"$netcdf_dir"/include"
+-    if [ "${netcdf_dir}" != '/usr' -a "$netcdf_dir" != '/usr/' ]; then
+-        netcdf_flag="-L${netcdf_dir}/lib $netcdf_flag"
+-    fi
+-    netcdf=$netcdf_dir"/include/netcdf.mod"
+-    if [ "$netcdfstatic" = 'no' ] ; then
+-      if [ "${netcdf_dir}" != '/usr' -a "${netcdf_dir}" != '/usr/' ]; then
+-          netcdfflagc="-L${netcdf_dir}/lib -lnetcdf"
+-          netcdfflagf="-L${netcdf_dir}/lib -lnetcdff -lnetcdf"
+-      else
+-          netcdfflagc="-lnetcdf"
+-          netcdfflagf="-lnetcdff -lnetcdf"
+-      fi
+-    else # Force static linking to netcdf
+-      printf "\tForcing static linking to external NetCDF\n"
+-      netcdfflagc=$netcdf_dir"/lib/libnetcdf.a"
+-      if [ ! -e "$netcdfflagc" ]; then
+-        echo "Error: '$netcdfflagc' not found."
+-        exit 1
++    printf "\tUsing external NetCDF in '$netcdf_dir' or '$netcdfc_dir' with '$netcdff_dir' \n"
++
++    # if individual netcdfc and fortran passed 
++    if [ "$netcdf_dir" = '' ]
++      netcdfcinc="-I"$netcdfc_dir"/include"
++      netcdffinc="-I"$netcdff_dir"/include"
++      # netcdf c and fortran directories passed
++      if [ "${netcdfc_dir}" != '/usr' -a "$netcdfc_dir" != '/usr/' ]; then
++          netcdf_flag="-L${netcdfc_dir}/lib $netcdf_flag"
++      fi
++      if [ "${netcdff_dir}" != '/usr' -a "$netcdff_dir" != '/usr/' ]; then
++          netcdf_flag="-L${netcdff_dir}/lib $netcdf_flag"
++      fi
++      netcdf=$netcdff_dir"/include/netcdf.mod"
++      if [ "$netcdfstatic" = 'no' ] ; then
++        if [ "${netcdfc_dir}" != '/usr' -a "${netcdfc_dir}" != '/usr/' ]; then
++            netcdfflagc="-L${netcdfc_dir}/lib -lnetcdf"
++            netcdfflagf="-L${netcdff_dir}/lib -lnetcdff -lnetcdf"
++        else
++            netcdfflagc="-lnetcdf"
++            netcdfflagf="-lnetcdff -lnetcdf"
++        fi
++      else # Force static linking to netcdf
++        printf "\tForcing static linking to external NetCDF\n"
++        netcdfflagc=$netcdfc_dir"/lib/libnetcdf.a"
++        if [ ! -e "$netcdfflagc" ]; then
++          echo "Error: '$netcdfflagc' not found."
++          exit 1
++        fi
++        netcdfflagf=$netcdff_dir"/lib/libnetcdff.a"
++        if [ ! -e "$netcdfflagf" ]; then
++          echo "Error: '$netcdfflagf' not found."
++          exit 1
++        fi
++        netcdfflagf="$netcdfflagf $netcdfflagc"
+       fi
+-      netcdfflagf=$netcdf_dir"/lib/libnetcdff.a"
+-      if [ ! -e "$netcdfflagf" ]; then
+-        echo "Error: '$netcdfflagf' not found."
+-        exit 1
++    else 
++      netcdfinc="-I"$netcdf_dir"/include"
++      if [ "${netcdf_dir}" != '/usr' -a "$netcdf_dir" != '/usr/' ]; then
++          netcdf_flag="-L${netcdf_dir}/lib $netcdf_flag"
++      fi
++      netcdf=$netcdf_dir"/include/netcdf.mod"
++      if [ "$netcdfstatic" = 'no' ] ; then
++        if [ "${netcdf_dir}" != '/usr' -a "${netcdf_dir}" != '/usr/' ]; then
++            netcdfflagc="-L${netcdf_dir}/lib -lnetcdf"
++            netcdfflagf="-L${netcdf_dir}/lib -lnetcdff -lnetcdf"
++        else
++            netcdfflagc="-lnetcdf"
++            netcdfflagf="-lnetcdff -lnetcdf"
++        fi
++      else # Force static linking to netcdf
++        printf "\tForcing static linking to external NetCDF\n"
++        netcdfflagc=$netcdf_dir"/lib/libnetcdf.a"
++        if [ ! -e "$netcdfflagc" ]; then
++          echo "Error: '$netcdfflagc' not found."
++          exit 1
++        fi
++        netcdfflagf=$netcdf_dir"/lib/libnetcdff.a"
++        if [ ! -e "$netcdfflagf" ]; then
++          echo "Error: '$netcdfflagf' not found."
++          exit 1
++        fi
++        netcdfflagf="$netcdfflagf $netcdfflagc"
+       fi
+-      netcdfflagf="$netcdfflagf $netcdfflagc"
+     fi
+     # Test netcdf compilation
+     test_netcdf_compile verbose
+     if [ $? -gt 0 ]; then
+-      echo "Error: Could not compile using NetCDF in '$netcdf_dir'"
++      echo "Error: Could not compile using NetCDF in '$netcdf_dir' or '$netcdfc_dir' and '$netcdff_dir'"
+       exit 1
+     fi
+     echo "OK"
+@@ -3732,6 +3797,8 @@
+ fi
+ if [ ! -z "$netcdf_dir" ] ; then
+   CPPTRAJOPTS="$CPPTRAJOPTS --with-netcdf=$netcdf_dir"
++elif [ ! -z "$netcdfc_dir" ]; then 
++  CPPTRAJOPTS="$CPPTRAJOPTS --with-netcdf-c=$netcdfc_dir --with-netcdf-fortran=$netcdff_dir"
+ else
+   CPPTRAJOPTS="$CPPTRAJOPTS --with-netcdf=$CPPTRAJHOME"
+ fi

--- a/setonix/repo_setonix/packages/amber/cpptraj_configure.patch
+++ b/setonix/repo_setonix/packages/amber/cpptraj_configure.patch
@@ -1,0 +1,58 @@
+--- AmberTools/src/cpptraj/configure	2020-04-28 09:19:43.000000000 +0800
++++ AmberTools/src/cpptraj/configure	2022-01-14 16:00:05.000000000 +0800
+@@ -10,7 +10,7 @@
+ #-------------------------------------------------------------------------------
+ # Print simple help message
+ UsageSimple() {
+-  echo "Usage: ./configure <OPTIONS> [gnu | intel | pgi | clang | cray]"
++  echo "Usage: ./configure <OPTIONS> [gnu | intel | pgi | clang | cray | cray-shasta-gnu | cray-shasta-cray | cray-shasta-aocc]"
+   echo "  OPTIONS:"
+   echo "    --help         : Display this message."
+   echo "    --prefix <dir> : Install CPPTRAJ to specified directory (default is this directory)."
+@@ -1104,13 +1104,35 @@
+       if [ $USE_OPENMP -eq 0 ] ; then
+         commonflags='-h noomp'
+       fi
++      PLATFORM='cray'
++      ;;
++    "cray-shasta-gnu" )
++      if [ -z "$CC" ]; then CC=cc; fi
++      if [ -z "$CXX" ]; then CXX=CC; fi
++      if [ -z "$FC" ]; then FC=ftn; fi
++      CXXFLAGS="-O3 $CXXFLAGS"
++      CFLAGS="-O3 $CFLAGS"
++      hostflags=''
++      optflags=''
++      ompflag='-fopenmp'
++      warnflag='-Wall' # This will also print cautions
++      fwarnflag='-Wall'
++      freefmtflag='-fallow-argument-mismatch -ffree-form'
++      foptflags=''
++      FLINK='-lgfortran'
++      picflag='-fpic'
++      C11FLAG='-std=c++11'
++      if [ $USE_OPENMP -eq 0 ] ; then
++        commonflags=''
++      fi
++      PLATFORM='cray'
+       ;;
+     * ) Err "Unknown compilers: $1" ;;
+   esac
+   # Unless specified fortran warnflag is same as C/C++
+   if [ -z "$fwarnflag" ] ; then fwarnflag=$warnflag ; fi
+   # Change to MPI compiler wrappers if specified. Not needed for cray.
+-  if [ $USE_MPI -ne 0 -a "$COMPILERS" != 'cray' ] ; then
++  if [ $USE_MPI -ne 0 -a "$COMPILERS" != 'cray' -a "$COMPILERS" != 'cray-shasta-gnu' -a "$COMPILERS" != 'cray-shasta-cray' -a "$COMPILERS" != 'cray-shasta-aocc' ] ; then
+     if [ $USE_MPI -eq 1 ] ; then
+       mpi_cc='mpicc'
+       mpi_cxx='mpicxx'
+@@ -1817,6 +1839,9 @@
+     'intel'      ) COMPILERS=$KEY ;;
+     'pgi'        ) COMPILERS=$KEY ;;
+     'cray'       ) COMPILERS=$KEY ;;
++    'cray-shasta-gnu'       ) COMPILERS=$KEY ;;
++    'cray-shasta-cray'       ) COMPILERS=$KEY ;;
++    'cray-shasta-aocc'       ) COMPILERS=$KEY ;;
+     'CXX'        ) CXX="$VALUE" ;;
+     'CC'         ) CC="$VALUE" ;;
+     'FC'         ) FC="$VALUE" ;;

--- a/setonix/repo_setonix/packages/amber/cpptraj_configure_netcdf.patch
+++ b/setonix/repo_setonix/packages/amber/cpptraj_configure_netcdf.patch
@@ -1,0 +1,127 @@
+--- a/ambertools_tmpdir/AmberTools/src/cpptraj/configure	2020-04-28 09:19:43.000000000 +0800
++++ b/ambertools_tmpdir/AmberTools/src/cpptraj/configure	2022-02-14 11:29:02.000000000 +0800
+@@ -10,7 +10,7 @@
+ #-------------------------------------------------------------------------------
+ # Print simple help message
+ UsageSimple() {
+-  echo "Usage: ./configure <OPTIONS> [gnu | intel | pgi | clang | cray]"
++  echo "Usage: ./configure <OPTIONS> [gnu | intel | pgi | clang | cray | cray-shasta-gnu | cray-shasta-cray | cray-shasta-aocc]"
+   echo "  OPTIONS:"
+   echo "    --help         : Display this message."
+   echo "    --prefix <dir> : Install CPPTRAJ to specified directory (default is this directory)."
+@@ -142,12 +142,14 @@
+ 
+ # ----- External Libraries -----------------------
+ # Total number of external libraries
+-NLIB=14
++NLIB=16
+ # Library indices
+-# Original: FFT ARPACK LAPACK BLAS NETCDF PARANC BZIP ZIP READLINE XDRFILE
++# Original: FFT ARPACK LAPACK BLAS NETCDF NETCDFC NETCDFFORTRAN PARANC BZIP ZIP READLINE XDRFILE
+ # Libraries containing definition of a function should appear *after*
+ # any source files or object files which use it.
+ LNETCDF=0
++LNETCDFC=14 # for separate netcdf fortran and c paths
++LNETCDFFORTRAN=15 # for separate netcdf fortran and c paths 
+ LPARANC=1    # Parallel NetCDF
+ LBZIP=2
+ LTNGFILE=3   # This has to come before ZLIB since it depends on ZLIB
+@@ -179,6 +181,26 @@
+ LIB_LINK[$LNETCDF]='dynamic'         # How to link the library
+ LIB_TYPE[$LNETCDF]='ld'              # ld = LDFLAGS, cpp = cpptraj, blank = special
+ 
++LIB_STAT[$LNETCDFC]='disabled'        # off, enabled, specified, amberopt, bundled, direct
++LIB_CKEY[$LNETCDFC]='netcdf-c'        # Command-line key for '-', '--with-' and '-no'
++LIB_HOME[$LNETCDFC]=''                # Library home directory (-L<home>)
++LIB_FLAG[$LNETCDFC]='-lnetcdf'        # Library linker flag
++LIB_STTC[$LNETCDFC]='libnetcdf.a'     # Expected static location relative to home
++LIB_D_ON[$LNETCDFC]='-DBINTRAJ'       # Directive if library on
++LIB_DOFF[$LNETCDFC]=''                # Directive if library off
++LIB_LINK[$LNETCDFC]='dynamic'         # How to link the library
++LIB_TYPE[$LNETCDFC]='ld'              # ld = LDFLAGS, cpp = cpptraj, blank = special
++
++LIB_STAT[$LNETCDFFORTRAN]='disabled'        # off, enabled, specified, amberopt, bundled, direct
++LIB_CKEY[$LNETCDFFORTRAN]='netcdf-fortran'  # Command-line key for '-', '--with-' and '-no'
++LIB_HOME[$LNETCDFFORTRAN]=''                # Library home directory (-L<home>)
++LIB_FLAG[$LNETCDFFORTRAN]='-lnetcdff'        # Library linker flag
++LIB_STTC[$LNETCDFFORTRAN]='libnetcdff.a'     # Expected static location relative to home
++LIB_D_ON[$LNETCDFFORTRAN]=''       # Directive if library on
++LIB_DOFF[$LNETCDFFORTRAN]=''                # Directive if library off
++LIB_LINK[$LNETCDFFORTRAN]='dynamic'         # How to link the library
++LIB_TYPE[$LNETCDFFORTRAN]='ld'              # ld = LDFLAGS, cpp = cpptraj, blank = special
++
+ LIB_STAT[$LPARANC]='off'
+ LIB_CKEY[$LPARANC]='pnetcdf'
+ LIB_HOME[$LPARANC]=''
+@@ -433,6 +455,16 @@
+   TestProgram "  Checking NetCDF" "$CXX" "$CXXFLAGS ${LIB_INCL[$LNETCDF]}" testp.cpp "${LIB_FLAG[$LNETCDF]}"
+ }
+ 
++TestNetcdfc() {
++  cat > testp.cpp <<EOF
++#include <cstdio>
++#include "netcdf.h"
++void unused() {int ncid; nc_open("foo.nc", 0, &ncid);}
++int main() { printf("Testing\n"); printf("%s\n",nc_strerror(0)); return 0; }
++EOF
++  TestProgram "  Checking NetCDF-C" "$CXX" "$CXXFLAGS ${LIB_INCL[$LNETCDFC]}" testp.cpp "${LIB_FLAG[$LNETCDFC]}"
++}
++
+ TestPnetcdf() {
+   cat > testp.cpp <<EOF
+ #include <cstdio>
+@@ -661,6 +693,7 @@
+   if [ "${LIB_TEST[$LBZIP]}" = 'yes'     ] ; then TestBzlib ; fi
+   if [ "${LIB_TEST[$LZIP]}" = 'yes'      ] ; then TestZlib ; fi
+   if [ "${LIB_TEST[$LNETCDF]}" = 'yes'   ] ; then TestNetcdf ; fi
++  if [ "${LIB_TEST[$LNETCDFC]}" = 'yes'   ] ; then TestNetcdfc ; fi
+   if [ "${LIB_TEST[$LPARANC]}" = 'yes'   ] ; then TestPnetcdf ; fi
+   if [ "${LIB_TEST[$LBLAS]}" = 'yes'     ] ; then TestMathlib ; fi
+   if [ "${LIB_TEST[$LARPACK]}" = 'yes'   ] ; then TestArpack ; fi
+@@ -1104,13 +1137,35 @@
+       if [ $USE_OPENMP -eq 0 ] ; then
+         commonflags='-h noomp'
+       fi
++      PLATFORM='cray'
++      ;;
++    "cray-shasta-gnu" )
++      if [ -z "$CC" ]; then CC=cc; fi
++      if [ -z "$CXX" ]; then CXX=CC; fi
++      if [ -z "$FC" ]; then FC=ftn; fi
++      CXXFLAGS="-O3 $CXXFLAGS"
++      CFLAGS="-O3 $CFLAGS"
++      hostflags=''
++      optflags=''
++      ompflag='-fopenmp'
++      warnflag='-Wall' # This will also print cautions
++      fwarnflag='-Wall'
++      freefmtflag='-fallow-argument-mismatch -ffree-form'
++      foptflags=''
++      FLINK='-lgfortran'
++      picflag='-fpic'
++      C11FLAG='-std=c++11'
++      if [ $USE_OPENMP -eq 0 ] ; then
++        commonflags=''
++      fi
++      PLATFORM='cray'
+       ;;
+     * ) Err "Unknown compilers: $1" ;;
+   esac
+   # Unless specified fortran warnflag is same as C/C++
+   if [ -z "$fwarnflag" ] ; then fwarnflag=$warnflag ; fi
+   # Change to MPI compiler wrappers if specified. Not needed for cray.
+-  if [ $USE_MPI -ne 0 -a "$COMPILERS" != 'cray' ] ; then
++  if [ $USE_MPI -ne 0 -a "$COMPILERS" != 'cray' -a "$COMPILERS" != 'cray-shasta-gnu' -a "$COMPILERS" != 'cray-shasta-cray' -a "$COMPILERS" != 'cray-shasta-aocc' ] ; then
+     if [ $USE_MPI -eq 1 ] ; then
+       mpi_cc='mpicc'
+       mpi_cxx='mpicxx'
+@@ -1817,6 +1872,9 @@
+     'intel'      ) COMPILERS=$KEY ;;
+     'pgi'        ) COMPILERS=$KEY ;;
+     'cray'       ) COMPILERS=$KEY ;;
++    'cray-shasta-gnu'       ) COMPILERS=$KEY ;;
++    'cray-shasta-cray'       ) COMPILERS=$KEY ;;
++    'cray-shasta-aocc'       ) COMPILERS=$KEY ;;
+     'CXX'        ) CXX="$VALUE" ;;
+     'CC'         ) CC="$VALUE" ;;
+     'FC'         ) FC="$VALUE" ;;

--- a/setonix/repo_setonix/packages/amber/nvhpc-boost.patch
+++ b/setonix/repo_setonix/packages/amber/nvhpc-boost.patch
@@ -1,0 +1,61 @@
+--- a/ambertools_tmpdir/AmberTools/src/ba/ambertools_tmpdir/oost/tools/build/src/engine/build.sh	2020-09-30 14:26:41.136036986 -0700
++++ b/ambertools_tmpdir/AmberTools/src/boost/tools/build/src/engine/build.sh	2020-09-30 14:27:29.634090876 -0700
+@@ -95,7 +95,7 @@
+     elif test -r /opt/intel/compiler50/ia32/bin/iccvars.sh ; then
+         BOOST_JAM_TOOLSET=intel-linux
+         BOOST_JAM_TOOLSET_ROOT=/opt/intel/compiler50/ia32/
+-    elif test_path pgcc ; then BOOST_JAM_TOOLSET=pgi
++    elif test_path nvc ; then BOOST_JAM_TOOLSET=pgi
+     elif test_path pathcc ; then BOOST_JAM_TOOLSET=pathscale
+     elif test_path como ; then BOOST_JAM_TOOLSET=como
+     elif test_path KCC ; then BOOST_JAM_TOOLSET=kcc
+@@ -231,7 +231,7 @@
+     ;;
+ 
+     pgi)
+-    BOOST_JAM_CC=pgcc
++    BOOST_JAM_CC=nvc
+     ;;
+ 
+     sun*)
+--- a/ambertools_tmpdir/AmberTools/src/boost/tools/build/src/tools/pgi.jam	2020-09-30 14:28:09.652483687 -0700
++++ b/ambertools_tmpdir/AmberTools/src/boost/tools/build/src/tools/pgi.jam	2020-09-30 14:28:34.421488935 -0700
+@@ -26,11 +26,11 @@
+ {
+   local condition = [ common.check-init-parameters pgi : version $(version) ] ;
+ 
+-  local l_command = [ common.get-invocation-command pgi : pgc++ : $(command) ] ;
++  local l_command = [ common.get-invocation-command pgi : nvc++ : $(command) ] ;
+ 
+   common.handle-options pgi : $(condition) : $(l_command) : $(options) ;
+     
+-  command_c = $(command_c[1--2]) $(l_command[-1]:B=pgcc) ;
++  command_c = $(command_c[1--2]) $(l_command[-1]:B=nvc) ;
+ 
+   toolset.flags pgi CONFIG_C_COMMAND $(condition) : $(command_c) ;
+ 
+--- a/ambertools_tmpdir/AmberTools/src/boost/tools/build/src/engine/build.jam	2020-09-30 14:40:16.983284833 -0700
++++ b/ambertools_tmpdir/AmberTools/src/boost/tools/build/src/engine/build.jam	2020-09-30 14:40:24.172997290 -0700
+@@ -309,7 +309,7 @@
+     -I$(--python-include) -I$(--extra-include)
+     : -L$(--python-lib[1]) -l$(--python-lib[2]) ;
+ ## Portland Group Pgi 6.2
+-toolset pgi pgcc : "-o " : -D
++toolset pgi nvc : "-o " : -D
+     :
+     [ opt --release : -s -O3 ]
+     [ opt --debug : -g ]
+--- a/ambertools_tmpdir/AmberTools/src/boost/libs/filesystem/src/operations.cpp	2020-09-30 15:07:31.998097202 -0700
++++ b/ambertools_tmpdir/AmberTools/src/boost/libs/filesystem/src/operations.cpp	2020-09-30 15:07:37.117892885 -0700
+@@ -2087,10 +2087,6 @@
+     return ok;
+   }
+ 
+-#if defined(__PGI) && defined(__USE_FILE_OFFSET64)
+-#define dirent dirent64
+-#endif
+-
+   error_code dir_itr_first(void *& handle, void *& buffer,
+     const char* dir, string& target,
+     fs::file_status &, fs::file_status &)
+

--- a/setonix/repo_setonix/packages/amber/nvhpc.patch
+++ b/setonix/repo_setonix/packages/amber/nvhpc.patch
@@ -1,0 +1,20 @@
+--- a/ambertools_tmpdir/AmberTools/src/configure2	2020-09-10 07:37:44.380726161 -0700
++++ b/ambertools_tmpdir/AmberTools/src/configure2	2020-09-10 07:38:22.052936370 -0700
+@@ -3190,7 +3190,7 @@
+       cd fftw-3.3 && \
+         ./configure --disable-doc --prefix=$amberprefix --libdir=$amberprefix/lib \
+         --enable-static $enable_mpi $mpicc $enable_debug $enable_sse\
+-        CC="$cc" CFLAGS="$cflags $coptflags" \
++        CC="$cc" CFLAGS="$cflags $cnooptflags" \
+         F77="$fc" FFLAGS="$fflags $foptflags" \
+         FLIBS="$flibs_arch" \
+         > ../fftw3_config.log 2>&1
+@@ -3287,6 +3287,8 @@
+       # b2 install will use intel-linux.compile.c++ (boost_1_64_0).
+       ./bootstrap.sh --prefix=$amberprefix --with-toolset=intel-linux > ../boost_config.log
+       ncerror=$?
++  elif [ $x86_64 = 'no' ] && [ "$compiler" = 'pgi' ]; then
++      ./bootstrap.sh --prefix=$amberprefix --with-toolset=pgi > ../boost_config.log
+   else
+       ./bootstrap.sh --prefix=$amberprefix > ../boost_config.log
+       ncerror=$?

--- a/setonix/repo_setonix/packages/amber/package.py
+++ b/setonix/repo_setonix/packages/amber/package.py
@@ -1,0 +1,275 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import shutil
+
+from spack import *
+
+
+class Amber(Package, CudaPackage):
+    """Amber is a suite of biomolecular simulation programs together
+       with Amber tools.
+
+       A manual download is required for Ambers. Spack will search your current
+       directory for the download files. Alternatively, add the files to a mirror
+       so that Spack can find them. For instructions on how to set up a mirror, see
+       https://spack.readthedocs.io/en/latest/mirrors.html
+
+       Note: Only certain versions of ambertools are compatible with amber.
+       Only the latter version of ambertools for each amber version is supported.
+       """
+
+    homepage = "https://ambermd.org/"
+    url = "file://{0}/Amber18.tar.bz2".format(os.getcwd())
+    manual_download = True
+
+    maintainers = ['hseara']
+
+    version(
+        '20', sha256='a4c53639441c8cc85adee397933d07856cc4a723c82c6bea585cd76c197ead75')
+    version(
+        '18', sha256='2060897c0b11576082d523fb63a51ba701bc7519ff7be3d299d5ec56e8e6e277')
+    version(
+        '16', sha256='3b7ef281fd3c46282a51b6a6deed9ed174a1f6d468002649d84bfc8a2577ae5d',
+        deprecated=True)
+
+    resources = {
+        # [version amber, version ambertools , sha256sum]
+        '20': ('20', 'b1e1f8f277c54e88abc9f590e788bbb2f7a49bcff5e8d8a6eacfaf332a4890f9'),
+        '18': ('19', '0c86937904854b64e4831e047851f504ec45b42e593db4ded92c1bee5973e699'),
+        '16': ('16', '7b876afe566e9dd7eb6a5aa952a955649044360f15c1f5d4d91ba7f41f3105fa'),
+    }
+    for ver, (ambertools_ver, ambertools_checksum) in resources.items():
+        resource(when='@{0}'.format(ver),
+                 name='AmberTools',
+                url='file://AmberTools{0}.tar.bz2'.format( #http://ambermd.org/downloads/AmberTools{0}.tar.bz2'.format(
+                      ambertools_ver),
+                 sha256=ambertools_checksum,
+                 destination='',
+                 placement='ambertools_tmpdir',
+                 )
+
+    patches = [
+        ('20', '1', '10780cb91a022b49ffdd7b1e2bf4a572fa4edb7745f0fc4e5d93b158d6168e42'),
+        ('20', '2', '9c973e3f8f33a271d60787e8862901e8f69e94e7d80cda1695f7fad7bc396093'),
+        ('20', '3', 'acb359dc9b1bcff7e0f1965baa9f3f3dc18eeae99c49f1103c1e2986c0bbeed8'),
+        ('20', '4', 'fd93c74f5ec80689023648cdd12b2c5fb21a3898c81ebc3fa256ef244932562a'),
+        ('20', '5', '8e46d5be28c002f560050a71f4851b01ef45a3eb66ac90d7e23553fae1370e68'),
+        ('20', '6', '8cf9707b3d08ad9242326f02d1861831ad782c9bfb0c46e7b1f0d4640571d5c1'),
+        ('20', '7', '143b6a09f774aeae8b002afffb00839212020139a11873a3a1a34d4a63fa995d'),
+        ('20', '8', 'a6fc6d5c8ba0aad3a8afe44d1539cc299ef78ab53721e28244198fd5425d14ad'),
+        ('20', '9', '5ce6b534bab869b1e9bfefa353d7f578750e54fa72c8c9d74ddf129d993e78cf'),
+        ('18', '1', '3cefac9a24ece99176d5d2d58fea2722de3e235be5138a128428b9260fe922ad'),
+        ('18', '2', '3a0707a9a59dcbffa765dcf87b68001450095c51b96ec39d21260ba548a2f66a'),
+        ('18', '3', '24c2e06f71ae553a408caa3f722254db2cbf1ca4db274542302184e3d6ca7015'),
+        ('18', '4', '51de613e8fda20cc92979265cf7179288df8c1af4202f02794ad7327fda2657b'),
+        ('18', '5', 'c70354bfa312603e4819efce11a242ddcc3830895453d9424f0c83f7ae98bc5b'),
+        ('18', '6', '3450433a8697b27e43172043be68d31515a7c7c00b2b248f84043dd70a2f59a8'),
+        ('18', '7', '10ba41422b7a3eb5b32bc6453231100544cf620c764ab8332c629a3b9fc749d4'),
+        ('18', '8', '73968dc0fd99bcbd5eae2223bd54f414879c062ac933948ba6b8b67383dc6a53'),
+        ('18', '9', 'e7d72fa31560f1e8ea572b8c73259d9fe512f56fbeb1b58ae014c43b9b5b6290'),
+        ('18', '10', '1bee419a3b0b686a729aa12515b0f96a9a8f43478ca2c01ea1661cc1698c6266'),
+        ('18', '11', '926557f0c137ea8dbf99a0487b25e131b12dfd39977d3e515f01f49187e6a09c'),
+        ('18', '12', '7e2645d539d257f7064808308048622818c9083dedfa4ac0a958cd15181231ac'),
+        ('18', '13', '95d2e33d0d05b8f9b6d8091d1c804271ec3a69e9aef792cc3b1ab8a2165eca3e'),
+        ('18', '14', 'a1adfb072f60ffcb67adb589df7c5578629441bee4ccb89ab635a6e8d7a35277'),
+        ('18', '15', '4deb3df329c05729561dcc7310e49059eaddc504c4210ad31fad11dc70f61742'),
+        ('18', '16', 'cf02f9b949127363bad1aa700ab662a3c7cf9ce0e2e4750e066d2204b9500a99'),
+        ('18', '17', '480300f949e0dd6402051810a9714adb388cf96e454a55346c76954cdd69413d'),
+        ('16', '1.txt', 'c7ef2303bb35131a48e2256c5a3c7b391efa73e2acf757d7e39760efb6320ed4'),
+        ('16', '2', 'a4db183f7c337a67f5d6b5015e3ae0af0d0edaa56894f0e9e3469c99708fed1c'),
+        ('16', '3', '5b279531c42445c6f58281dd94588460218d2258ec9013c8447f3e2b7b81bf02'),
+        ('16', '4', '035bddd63bc9d5fd6de26beab31887e5c14c3caa4958d2424d72f3c49832bd42'),
+        ('16', '5', '02d8a1fcb6baa466de4e3683afa48076394acd805f490fbbe50ab19040675136'),
+        ('16', '6', '69a3e64d75255d9179c98a2b3a63fe76d5be08c9fc41f27ac197663c97915113'),
+        ('16', '7', '0d674c907758e90a168345e6b35b7a0de79c2ead390ab372465a354fcab67d17'),
+        ('16', '8', 'd722c0db46af905a5bd13b60e3130c4ddfb0c9da86df0a33253e5f8d53068946'),
+        ('16', '9', 'b563e744fbc50c1240d23df369750879df2cec69fba933704b97a73a66d9c4f1'),
+        ('16', '10', '99affc65740080b7a1ab87c5c9119bf5be7cf47b2b2d8fc13407d35bd2ba6238'),
+        ('16', '11', '86b89dbcae80ef48720fd3c7da88cffbdabfd4021af5a827339b56a33ddae27a'),
+        ('16', '12', 'c8d61d1efbd44086f88d74ad9e07dfdc3737dc7053c7d2503131ba0918973a03'),
+        ('16', '13', '5ce28e6e0118a4780ad72fc096e617c874cde7d140e15f87451babb25aaf2d8f'),
+        ('16', '14', '93703e734e76da30a5e050189a66d5a4d6bec5885752503c4c798e2f44049080'),
+        ('16', '15', 'a156ec246cd06688043cefde24de0d715fd46b08f5c0235015c2c5c3c6e37488'),
+    ]
+    for ver, num, checksum in patches:
+        patch_url_str = 'https://ambermd.org/bugfixes/{0}.0/update.{1}'
+        patch(patch_url_str.format(ver, num),
+              sha256=checksum, level=0, when='@{0}'.format(ver))
+
+    # Patch to add ppc64le in config.guess
+    patch('ppc64le.patch', when='@18: target=ppc64le:')
+
+    # Patch to add aarch64 in config.guess
+    patch('aarch64.patch', when='@18: target=aarch64:')
+
+    # Workaround to modify the AmberTools script when using the NVIDIA
+    # compilers
+    patch('nvhpc.patch', when='@18: %nvhpc')
+
+    # Workaround to use NVIDIA compilers to build the bundled Boost
+    patch('nvhpc-boost.patch', when='@18: %nvhpc')
+
+    # workaround for cray shasta gnu compilation ( and soon cray-shasta-*)
+    #patch('ambertools_configure2.patch', when='@20:')
+    #patch('cpptraj_configure.patch', when='@20:')
+    #patch('ambertools_configure2_for_netcdf.patch', when='@20:')
+    patch('ambertools_configure2_cray_shasta.patch', when='@20:')
+    patch('cpptraj_configure_netcdf.patch', when='@20:')
+
+    variant('mpi', description='Build MPI executables',
+            default=True)
+    variant('openmp', description='Use OpenMP pragmas to parallelize',
+            default=False)
+    variant('x11', description='Build programs that require X11',
+            default=False)
+    variant('update', description='Update the sources prior compilation',
+            default=False)
+
+    depends_on('zlib')
+    depends_on('bzip2')
+    depends_on('flex', type='build')
+    depends_on('bison', type='build')
+    depends_on('netcdf-fortran')
+    depends_on('fftw-api@3')
+    # Potential issues with openmpi 4
+    # (http://archive.ambermd.org/201908/0105.html)
+    depends_on('mpi', when='+mpi')
+
+    # Cuda dependencies
+    depends_on('cuda@:10.2.89', when='@18:+cuda')
+    depends_on('cuda@7.5.18', when='@:16+cuda')
+
+    # conflicts
+    conflicts('+x11', when='platform=cray',
+              msg='x11 amber applications not available for cray')
+    conflicts('+openmp', when='%clang',
+              msg='OpenMP not available for the clang compiler')
+    conflicts('+openmp', when='%apple-clang',
+              msg='OpenMP not available for the Apple clang compiler')
+    conflicts('+openmp', when='%pgi',
+              msg='OpenMP not available for the pgi compiler')
+
+    def setup_build_environment(self, env):
+        amber_src = self.stage.source_path
+        env.set('AMBERHOME', amber_src)
+
+        # The bundled Boost does not detect the bzip2 package, but
+        # will silently fall back to a system install (if available).
+        # Force it to use the bzip2 package.
+        env.prepend_path('CPATH', self.spec['bzip2'].prefix.include)
+
+        # CUDA
+        if self.spec.satisfies('+cuda'):
+            env.set('CUDA_HOME', self.spec['cuda'].prefix)
+
+    def install(self, spec, prefix):
+        # The resource command does not allow us to expand the package in the
+        # root stage folder as required, as it already contains files. Here we
+        # install AmberTools where it should be, which results in 3 copies of
+        # the  ambertools (~9 GB). This has to be improved in the future.
+        install_tree('ambertools_tmpdir', '.')
+        shutil.rmtree(join_path(self.stage.source_path, 'ambertools_tmpdir'))
+
+        # Select compiler style
+        # previously could use satisfies gcc, cce, etc but 
+        # with cray-shasta and current patches to include cray-shasta-*
+        # we remove cray and gnu and replace with cray-shasta-cray
+        # cray-shasta-gnu
+        # note that will need to add cray-shasta-* to patch
+        # need better way of determining shasta but 
+        # not obvious how to do so yet
+        if self.spec.satisfies('%cce'):
+            compiler = 'cray-shasta-cray'
+        elif self.spec.satisfies('%gcc'):
+            compiler = 'cray-shasta-gnu'
+        elif self.spec.satisfies('%intel'):
+            compiler = 'intel'
+        elif self.spec.satisfies('%pgi'):
+            compiler = 'pgi'
+        elif self.spec.satisfies('%nvhpc'):
+            compiler = 'pgi'
+        elif self.spec.satisfies('%clang'):
+            compiler = 'clang'
+        else:
+            raise InstallError('Unknown compiler, exiting!!!')
+
+        # if self.spec.satisfies('%cce'):
+        #     compiler = 'cray'
+        # elif self.spec.satisfies('%gcc'):
+        #     compiler = 'gnu'
+        # elif self.spec.satisfies('%intel'):
+        #     compiler = 'intel'
+        # elif self.spec.satisfies('%pgi'):
+        #     compiler = 'pgi'
+        # elif self.spec.satisfies('%nvhpc'):
+        #     compiler = 'pgi'
+        # elif self.spec.satisfies('%clang'):
+        #     compiler = 'clang'
+        # else:
+        #     raise InstallError('Unknown compiler, exiting!!!')
+
+        # Base configuration
+        conf = Executable('./configure')
+        base_args = ['--skip-python',
+                     '--with-netcdf-c', self.spec['netcdf-c'].prefix, 
+                     '--with-netcdf-fortran', self.spec['netcdf-fortran'].prefix, 
+                    #  '-nofftw3', 
+                     ]
+        if self.spec.satisfies('~x11'):
+            base_args += ['-noX11']
+
+        # Update the sources: Apply all upstream patches
+        if self.spec.satisfies('+update'):
+            update = Executable('./update_amber')
+            update(*(['--update']))
+        else:
+            base_args += ['--no-updates']
+
+        # Non-x86 architecture
+        if self.spec.target.family != 'x86_64':
+            base_args += ['-nosse']
+
+        # Single core
+        conf(*(base_args + [compiler]))
+        make('install')
+
+        # CUDA
+        if self.spec.satisfies('+cuda'):
+            conf(*(base_args + ['-cuda', compiler]))
+            make('install')
+
+        # MPI
+        if self.spec.satisfies('+mpi') and self.spec.satisfies('~openmp'):
+            conf(*(base_args + ['-mpi', compiler]))
+            make('install')
+
+        # Openmp
+        if self.spec.satisfies('+openmp') and self.spec.satisfies('~mpi'):
+            make('clean')
+            conf(*(base_args + ['-openmp', compiler]))
+            make('openmp')
+
+        # MPI and OpenMP 
+        if self.spec.satisfies('+openmp') and self.spec.satisfies('+mpi'):
+            conf(*(base_args + ['-mpi -openmp', compiler]))
+            make('install')
+
+        # CUDA + MPI
+        if self.spec.satisfies('+cuda') and self.spec.satisfies('+mpi'):
+            make('clean')
+            conf(*(base_args + ['-cuda', '-mpi', compiler]))
+            make('install')
+
+        # just install everything that was built
+        install_tree('.', prefix)
+
+    def setup_run_environment(self, env):
+        env.set('AMBER_PREFIX', self.prefix)
+        env.set('AMBERHOME', self.prefix)
+        # CUDA
+        if self.spec.satisfies('+cuda'):
+            env.prepend_path('LD_LIBRARY_PATH', self.spec['cuda'].prefix.lib)

--- a/setonix/repo_setonix/packages/amber/ppc64le.patch
+++ b/setonix/repo_setonix/packages/amber/ppc64le.patch
@@ -1,0 +1,24 @@
+--- a/ambertools_tmpdir/AmberTools/src/fftw-3.3/config.guess	2020-09-30 13:28:45.035344970 -0700
++++ b/ambertools_tmpdir/AmberTools/src/fftw-3.3/config.guess	2020-09-30 13:28:55.534923364 -0700
+@@ -953,6 +953,9 @@
+     ppc64:Linux:*:*)
+ 	echo powerpc64-unknown-linux-gnu
+ 	exit ;;
++    ppc64le:Linux:*:*)
++       echo powerpc64le-unknown-linux-gnu
++       exit ;;
+     ppc:Linux:*:*)
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;
+--- a/ambertools_tmpdir/AmberTools/src/xblas/config/config.guess	2020-09-30 15:30:11.573779015 -0700
++++ b/ambertools_tmpdir/AmberTools/src/xblas/config/config.guess	2020-09-30 15:30:46.932366326 -0700
+@@ -967,6 +967,9 @@
+     ppc64:Linux:*:*)
+ 	echo powerpc64-unknown-linux-gnu
+ 	exit ;;
++    ppc64le:Linux:*:*)
++       echo powerpc64le-unknown-linux-gnu
++       exit ;;
+     ppc:Linux:*:*)
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;


### PR DESCRIPTION
Added patches to the configure scritps to handle cray shasta for gnu and separate netcdf-c and netcdf-fortran installation directories.
The updates to a cray-shasta build are currently for gnu only, built with cray-shasta-gnu as the compiler selection. Furhter updates to this will be required for cray compilers and aocc compilers.
Currently the code can manually build but there is an remaining issue with spack builds. When installing with spack, the resulting make file will try to build a larger selection of amber tools, which do not compile. Manually configuring the code with seeminly the same configure command does not try to make these tools and will successfully build the code. Further digging is required to determine what the issue is.