### PR TITLE
Update/setup singularity

### DIFF
--- a/setonix/setup/module_shpc.lua
+++ b/setonix/setup/module_shpc.lua
@@ -13,7 +13,7 @@ prereq("PrgEnv-gnu", "gcc/GCC_VERSION")
 conflict("PrgEnv-cray", "PrgEnv-aocc")
 
 load("PYTHON_MODULEFILE")
-load("singularity/SINGULARITY_VERSION")
+load("SINGULARITY_MODULEFILE")
 
 setenv("SINGULARITY_HPC_HOME","/software/setonix/DATE_TAG/SHPC_INSTALL_DIR")
 

--- a/setonix/setup/module_shpc.lua
+++ b/setonix/setup/module_shpc.lua
@@ -8,10 +8,6 @@ whatis([[Version : SHPC_VERSION]])
 whatis([[Short description : Local filesystem registry for containers (intended for HPC) using Lmod or Environement Modules. Works for users and admins. ]])
 help([[Local filesystem registry for containers (intended for HPC) using Lmod or Environement Modules. Works for users and admins.]])
 
--- requires gcc, because singularity (loaded below) is only built with gcc
-prereq("PrgEnv-gnu", "gcc/GCC_VERSION")
-conflict("PrgEnv-cray", "PrgEnv-aocc")
-
 load("PYTHON_MODULEFILE")
 load("SINGULARITY_MODULEFILE")
 

--- a/setonix/setup/setup_shpc.sh
+++ b/setonix/setup/setup_shpc.sh
@@ -58,7 +58,7 @@ shpc config set default_version:false
 # user install location for containers
 shpc config set container_base:/software/\$PAWSEY_PROJECT/\$USER/setonix/containers/sif
 # singularity module
-shpc config set singularity_module:singularity/${singularity_version}
+shpc config set singularity_module:${singularity_name}/${singularity_version}
 # enable wrapper scripts
 shpc config set wrapper_scripts:enabled:true
 # GPU support (Phase 2)
@@ -83,7 +83,7 @@ sed \
   -e "s/SHPC_INSTALL_DIR/${shpc_install_dir}/g" \
   -e "s/GCC_VERSION/${gcc_version}/g" \
   -e "s/PYTHON_MODULEFILE/${python_name}\/${python_version}/g" \
-  -e "s/SINGULARITY_VERSION/${singularity_version}/g" \
+  -e "s/SINGULARITY_MODULEFILE/${singularity_name}\/${singularity_version}/g" \
   -e "s/DATE_TAG/${date_tag}/g" \
   -e "s/PYTHON_MAJORMINOR/${python_version_major}.${python_version_minor}/g" \
  pawsey-spack-config/setonix/setup/module_${shpc_name}.lua \

--- a/setonix/setup/setup_singularity_symlink.sh
+++ b/setonix/setup/setup_singularity_symlink.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# source setup variables
+script_dir="$(dirname $0)"
+. ${script_dir}/variables.sh
+
+# This script just does one thing
+# It creates a symlink from {spack modules}/{arch}/{compiler}
+# to the Pawsey utilities module directory
+# In this way, Singularity is available regardless the loaded PrgEng/compiler
+# It will still work, thanks to RPATH
+
+src_dir="${root_dir}/modules/${cpu_arch}/gcc/${gcc_version}/utilities/${singularity_name}"
+dst_dir="${root_dir}/${singularity_symlink_module_dir}"
+
+mkdir -p ${dst_dir}
+
+for version in $( ls ${src_dir} ) ; do
+  ln -s ${src_dir}/${version} ${dst_dir}/${version}
+done
+
+

--- a/setonix/setup/variables.sh
+++ b/setonix/setup/variables.sh
@@ -20,6 +20,8 @@ pip_version="21.1.2" # has to match the version in the Spack env yaml
 gcc_version="10.3.0"
 cce_version="12.0.1"
 aocc_version="3.0.0"
+# architecture of login/compute nodes (needed by Singularity symlink module)
+cpu_arch="zen3"
 
 # python version info (no editing needed)
 python_version_major="$( echo $python_version | cut -d '.' -f 1 )"

--- a/setonix/setup/variables.sh
+++ b/setonix/setup/variables.sh
@@ -34,6 +34,9 @@ shpc_spackuser_openfoam_add_prefix="containerised-"
 # name of SHPC module: decide this once and for all
 shpc_name="shpc"
 
+# name of Singularity module (Spack has singularity and singularityce)
+singularity_name="singularity"
+
 # NOTE: these are all relative to root_dir above
 # root location for Pawsey custom builds
 custom_root_dir="custom"
@@ -54,6 +57,9 @@ shpc_containers_dir="${containers_root_dir}/sif"
 shpc_install_dir="${utilities_root_dir}/software/${shpc_name}"
 # location of SHPC utility modulefile
 shpc_module_dir="${utilities_modules_dir}/${shpc_name}"
+
+# location of Singularity modulefile (arch/compiler free symlink)
+singularity_symlink_module_dir="${utilities_modules_dir}/${singularity_name}"
 
 # location for Spack modulefile
 spack_module_dir="${utilities_modules_dir}/spack"


### PR DESCRIPTION
Create  an additional, symlinked Singularity modulefile, which sits in the Pawsey utilities module directory.
In this way, Singularity is available with any compiler/PrgEnv. SHPC will work, too.

Singularity will still work, thanks to the RPATH method used by Spack.