### PR TITLE
setonix: openssl and openssh external set to buildable

### DIFF
--- a/setonix/configs/site_allusers/packages.yaml
+++ b/setonix/configs/site_allusers/packages.yaml
@@ -278,7 +278,7 @@ packages:
     externals:
     - spec: openssh@8.1p1
       prefix: /usr
-    buildable: false
+#    buildable: false
   openssl:
     externals:
     - spec: openssl@1.1.1d

--- a/setonix/configs/site_allusers/packages.yaml
+++ b/setonix/configs/site_allusers/packages.yaml
@@ -307,7 +307,7 @@ packages:
 # fooling spack is risky; however, as of spack v0.17.0, 
 # these 2 versions are equivalent in recipes for depends/conflicts
 #    - spec: openssl@1.1.1d
-    - spec: openssl@1.1.1
+    - spec: openssl@1.1
       prefix: /usr
     buildable: false
   pkg-config:

--- a/setonix/configs/site_allusers/packages.yaml
+++ b/setonix/configs/site_allusers/packages.yaml
@@ -74,7 +74,7 @@ packages:
   # preferred versions (for 2022.05) and variants, python
   python:
     version: [3.9.7]
-    variants: '+optimizations+ssl'
+    variants: '+optimizations'
   gdbm:
     version: [1.19]
   gettext:

--- a/setonix/configs/site_allusers/packages.yaml
+++ b/setonix/configs/site_allusers/packages.yaml
@@ -283,7 +283,7 @@ packages:
     externals:
     - spec: openssl@1.1.1d
       prefix: /usr
-    buildable: false
+#    buildable: false
   pkg-config:
     externals:
     - spec: pkg-config@0.29.2

--- a/setonix/configs/site_allusers/packages.yaml
+++ b/setonix/configs/site_allusers/packages.yaml
@@ -294,14 +294,22 @@ packages:
     buildable: false
   openssh:
     externals:
-    - spec: openssh@8.1p1
+# getting rid of letter in version, as clingo/spack has buggy behaviour
+# fooling spack is risky; however, openssh website mentions 
+# these 2 versions are equivalent; also seem equivalent within spack
+#    - spec: openssh@8.1p1
+    - spec: openssh@8.1
       prefix: /usr
-#    buildable: false
+    buildable: false
   openssl:
     externals:
-    - spec: openssl@1.1.1d
+# getting rid of letter in version, as clingo/spack has buggy behaviour
+# fooling spack is risky; however, as of spack v0.17.0, 
+# these 2 versions are equivalent in recipes for depends/conflicts
+#    - spec: openssl@1.1.1d
+    - spec: openssl@1.1.1
       prefix: /usr
-#    buildable: false
+    buildable: false
   pkg-config:
     externals:
     - spec: pkg-config@0.29.2


### PR DESCRIPTION
1. set openssh to buildable
2. set openssl to buildable
3. took out default +ssl from python