### PR TITLE
Update spack.yaml

### DIFF
--- a/setonix/environments/env_num_libs/spack.yaml
+++ b/setonix/environments/env_num_libs/spack.yaml
@@ -43,6 +43,12 @@ spack:
     # builds OK with openblas
     - slate@2021.05.02 build_type=Release ^openblas
     - plumed@2.7.2
+    # AMD AOCL
+    - amdblis@3.0
+    - amdscalapack@3.0
+    - aocl-sparse@3.0
+    - amdfftw@3.0
+    - amdlibm@3.0
 
     
     # some heavier numerical library builds 


### PR DESCRIPTION
Adds AMD AOCL libraries. `amdlibflame` still has some issues building due to Python.