### PR TITLE
Patch plumed missing include file.

### DIFF
--- a/setonix/repo/packages/plumed/package.py
+++ b/setonix/repo/packages/plumed/package.py
@@ -138,6 +138,9 @@ class Plumed(AutotoolsPackage):
     conflicts('+funnel', when='@:2.6.99', msg='funnel was added from version 2.7')
     conflicts('+opes', when='@:2.6.99', msg='opes was added from version 2.7')
 
+    # Fixes
+    patch('plumed-2.6.1-include-limits.patch', when='@2.6.1')
+
     force_autoreconf = True
 
     parallel = False

--- a/setonix/repo/packages/plumed/plumed-2.6.1-include-limits.patch
+++ b/setonix/repo/packages/plumed/plumed-2.6.1-include-limits.patch
@@ -1,0 +1,12 @@
+*** a/src/lepton/Operation.h	Wed Jul  8 14:41:26 2020
+--- b/src/lepton/Operation.h	Mon May 30 17:19:20 2022
+***************
+*** 68,73 ****
+--- 68,74 ----
+  #include "CustomFunction.h"
+  #include "Exception.h"
+  #include <cmath>
++ #include <limits>
+  #include <map>
+  #include <string>
+  #include <vector>


### PR DESCRIPTION
Add a patch for plumed 2.6.1 that fixes a build failure due to a missing #include.