### PR TITLE
update to spack.yamls to include specific py ver

### DIFF
--- a/setonix/environments/env_devel/spack.yaml
+++ b/setonix/environments/env_devel/spack.yaml
@@ -7,8 +7,7 @@ spack:
     - caliper@2.7.0 +fortran build_type=Release
     #- hpctoolkit@2021.10.15 +mpi ^dyninst@11.0.1 #issues with elfutils version on setonix and possibly binutils
     - hpcviewer@2021.10
-    - py-hatchet@1.3.1a0
-
+    - py-hatchet@1.3.1a0 ^python@3.9.15
   specs:
   - matrix:
     - [$packages]

--- a/setonix/environments/env_io_libs/spack.yaml
+++ b/setonix/environments/env_io_libs/spack.yaml
@@ -16,7 +16,7 @@ spack:
   - netcdf-set:
     - netcdf-c@4.8.1 +hdf4 +parallel-netcdf
     - netcdf-cxx@4.2
-    - netcdf-cxx4@4.3.1
+    - netcdf-cxx4@4.3.1 ^python@3.9.15
     - netcdf-fortran@4.5.3
     - parallel-netcdf@1.12.2
   # currently netcdf has issues because packages require
@@ -29,7 +29,6 @@ spack:
   #   ^zlib@1.2.5'
   # and zlib is ususually does not require a specific version, same for cmake 
   # need to think about the approach. 
-
   # add package specs to the `specs` list
   specs:
   - matrix:
@@ -50,7 +49,7 @@ spack:
     - [$adios-set]
     - ['%gcc@12.1.0']
     - [target=zen3]
-    - [+python, ~python]
+    - [+python ^python@3.9.15, ~python]
     - [+hdf5]
     - [^hdf5@1.12.1 +hl +fortran +szip api=v112 build_type=Release]
     #- [^hdf5@1.12.1 +hl +fortran +szip api=v112 build_type=Release, ^hdf5@1.12.1 +hl +fortran +szip api=v110 build_type=Release,

--- a/setonix/environments/env_langs/spack.yaml
+++ b/setonix/environments/env_langs/spack.yaml
@@ -10,7 +10,7 @@ spack:
     - perl@5.34.0
     - ruby@3.0.1
     # latest version of rust available may have issues but spack listed latest release is fine. 
-    - rust@1.51.0
+    - rust@1.51.0 ^python@3.9.15
   - py-utilities:
     - py-pip@22.2.2
     - py-setuptools@57.4.0

--- a/setonix/environments/env_num_libs/spack.yaml
+++ b/setonix/environments/env_num_libs/spack.yaml
@@ -19,15 +19,9 @@ spack:
     - kokkos@3.4.01 +hwloc +memkind +numactl +hpx +hpx_async_dispatch +tuning ~openmp
       cxxstd=14 build_type=Release ^hpx@1.6.0 +async_mpi malloc=jemalloc max_cpu_count=128
       networking=mpi build_type=Release
-  - numerical:
-    - openblas@0.3.15 threads=openmp
-    - netlib-lapack@3.9.1 build_type=Release
-    - netlib-scalapack@2.1.0
-    - blaspp@2021.04.01 ~cuda build_type=Release ^openblas
-    - eigen@3.4.0 build_type=Release # charris: build ok on Joey 2021-12-16
-    - fftw@2.1.5 +openmp precision=float,double # fftw 2 does not support long doubles
-    - fftw@3.3.9 +openmp precision=float,double,long_double
-    - gsl@2.6
+  # because of odd concretization of packages with python dependences defaulting to 3.9.9 and not the 
+  # version specified in the packages.yaml, separate packages between those with python dep and those without
+  - numerical-with-python:
     # updates to lapack/blas for new hardware like GPUs  
     # TODO: no need for magma in phase 1 as it is GPU only 
     #- magma@2.5.4 
@@ -50,7 +44,16 @@ spack:
     # for the moment trilinos disabled 
     #- petsc@3.15.5 +fftw +trilinos +hwloc +openmp +complex ~cuda
     - petsc@3.15.5 +fftw ~trilinos +hwloc +openmp +complex ~cuda
-  - amd:
+  - numerical:
+    - openblas@0.3.15 threads=openmp
+    - netlib-lapack@3.9.1 build_type=Release
+    - netlib-scalapack@2.1.0
+    - blaspp@2021.04.01 ~cuda build_type=Release ^openblas
+    - eigen@3.4.0 build_type=Release # charris: build ok on Joey 2021-12-16
+    - fftw@2.1.5 +openmp precision=float,double # fftw 2 does not support long doubles
+    - fftw@3.3.9 +openmp precision=float,double,long_double
+    - gsl@2.6
+  - amd-with-python:
     # AMD AOCL
     - amdblis@3.0 threads=openmp
     # variant below useful for at least one PaCER
@@ -58,19 +61,31 @@ spack:
     - amdlibflame@3.0 threads=openmp
     - amdscalapack@3.0 build_type=Release
     - aocl-sparse@3.0 build_type=Release
+    #- amdfftw@3.0 precision=float,double,long_double
+  - amd:
     - amdfftw@3.0 precision=float,double,long_double
-    - amdlibm@3.0
   specs:
   - matrix:
     - [$parallel]
     - ['%gcc@12.1.0']
+    - [^python@3.9.15]
     - [target=zen3]
   - matrix:
     - [$numerical]
     - ['%gcc@12.1.0']
     - [target=zen3]
   - matrix:
+    - [$numerical-with-python]
+    - ['%gcc@12.1.0']
+    - [^python@3.9.15]
+    - [target=zen3]
+  - matrix:
     - [$amd]
-    - ['%gcc@12.1.0', '%aocc@3.2.0']
+    - ['%gcc@12.1.0', '%cce@14.0.3', '%aocc@3.2.0']
+    - [target=zen3]
+  - matrix:
+    - [$amd-with-python]
+    - ['%gcc@12.1.0', '%cce@14.0.3', '%aocc@3.2.0']
+    - [^python@3.9.15]
     - [target=zen3]
   view: false

--- a/setonix/environments/env_python/spack.yaml
+++ b/setonix/environments/env_python/spack.yaml
@@ -21,12 +21,10 @@ spack:
     - py-plotly@5.2.2
     - py-scikit-learn@1.0.1
     - py-scipy@1.7.1
-
   # need these here, too, for the python collection
   - utilities:
     - py-pip@22.2.2
     - py-setuptools@57.4.0
-
   specs:
   - matrix:
     - [python@3.9.15]

--- a/setonix/environments/env_s3_clients/spack.yaml
+++ b/setonix/environments/env_s3_clients/spack.yaml
@@ -19,6 +19,7 @@ spack:
   specs:
   - matrix:
     - [$s3-python-set]
+    - [^python@3.9.15]
     - ['%gcc@12.1.0']
     - [target=zen2, target=zen3]
   - matrix:

--- a/setonix/environments/env_utils/spack.yaml
+++ b/setonix/environments/env_utils/spack.yaml
@@ -2,20 +2,23 @@ spack:
 # note: preferred versions are set in packages.yaml
   definitions:
   - packages:
+    
 # py-pip and py-setuptools: installed in env_langs
 # snakemake: docs recommend to install with conda
     - ffmpeg@4.4 +avresample
-    - gnuplot@5.4.2 +X  #^gettext@0.21
-    - llvm@14.0.0 ~omp_as_runtime ~clang ~compiler-rt ~polly ~gold
+    - gnuplot@5.4.2 +X  ^python@3.9.15 #^gettext@0.21
+    - llvm@14.0.0 ~omp_as_runtime ~clang ~compiler-rt ~polly ~gold ^python@3.9.15
     - nextflow@22.04.3
     - parallel@20210922
-    - reframe@3.10.1
-    - reframe@3.4
+    - reframe@3.10.1 ^python@3.9.15
+    - reframe@3.4 ^python@3.9.15
     - singularity@3.8.6
     - mpifileutils@0.11+lustre
+    
 # utilities for Nextflow Tower
     - tower-agent@0.4.5
     - tower-cli@0.7.0
+    
 # add nano here for now
     - nano@6.3
   - licensed:


### PR DESCRIPTION
The fact that the desired python does not contain a hash in the recipe seems to introduce a bug in the concretization. This bug results in a version of python other than what is requested being built. This bug is fixed by explicitly having the python version in the environment.