### PR TITLE
Only use python%gcc12 in env_python.

### DIFF
--- a/setonix/environments/env_python/spack.yaml
+++ b/setonix/environments/env_python/spack.yaml
@@ -27,8 +27,8 @@ spack:
     - py-setuptools@57.4.0
   specs:
   - matrix:
-    - [python@3.9.15]
-    - ['%gcc@12.1.0', '%cce@14.0.3', '%aocc@3.2.0']
+    - [python@3.9.15 +optimizations]
+    - ['%gcc@12.1.0']
     - [target=zen3]
   - matrix:
     - [$packages, $utilities]


### PR DESCRIPTION
If we have multiple pythons the creation of the hpc collection view breaks.

Other Python instances will still be compiled in env_langs. This environment is purely needed for the HPC python collection view.