### PR TITLE
Moves the `~/.spack` directory to /software

### DIFF
--- a/fixes/dot_spack.patch
+++ b/fixes/dot_spack.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/spack/spack/paths.py b/lib/spack/spack/paths.py
-index fc617342e8..6e25762252 100644
+index fc617342e8..885f00081a 100644
 --- a/lib/spack/spack/paths.py
 +++ b/lib/spack/spack/paths.py
 @@ -75,6 +75,22 @@
@@ -39,7 +39,7 @@ index fc617342e8..6e25762252 100644
  # User configuration and caches in $HOME/.spack
  def _get_user_config_path():
 -    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or "~%s.spack" % os.sep)
-+    return os.path.expanduser(_get_pawsey_custom_path())
++    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or _get_pawsey_custom_path())
  
  
  # Configuration in /etc/spack on the system

--- a/fixes/dot_spack.patch
+++ b/fixes/dot_spack.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/spack/spack/paths.py b/lib/spack/spack/paths.py
+index fc617342e8..c4f7b4277d 100644
+--- a/lib/spack/spack/paths.py
++++ b/lib/spack/spack/paths.py
+@@ -120,7 +120,12 @@ def _get_user_cache_path():
+ 
+ # User configuration and caches in $HOME/.spack
+ def _get_user_config_path():
+-    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or "~%s.spack" % os.sep)
++    _mysoftware_path = os.getenv("MYSOFTWARE")
++    if _mysoftware_path is None:
++        user_path =  ("~%s.spack" % os.sep)
++    else:
++        user_path = f"{_mysoftware_path}{os.sep}setonix{os.sep}.spack_user_config"
++    return os.path.expanduser(user_path)
+ 
+ 
+ # Configuration in /etc/spack on the system

--- a/fixes/dot_spack.patch
+++ b/fixes/dot_spack.patch
@@ -1,18 +1,45 @@
 diff --git a/lib/spack/spack/paths.py b/lib/spack/spack/paths.py
-index fc617342e8..c4f7b4277d 100644
+index fc617342e8..6e25762252 100644
 --- a/lib/spack/spack/paths.py
 +++ b/lib/spack/spack/paths.py
-@@ -120,7 +120,12 @@ def _get_user_cache_path():
+@@ -75,6 +75,22 @@
+ gpg_path = os.path.join(opt_path, "spack", "gpg")
  
- # User configuration and caches in $HOME/.spack
- def _get_user_config_path():
--    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or "~%s.spack" % os.sep)
+ 
++def _get_pawsey_custom_path():
++    """
++    At Pawsey we would like to avoid writing a user's Spack files in the /home
++    directory. We use a filesystem dedicated to software installations instead.
++    There are several reasons. One is a limitation on the number of files we allow
++    in /home. The second is that we want to have a different user-level configuration
++    and cache directory for each software stack deployment.
++    """
 +    _mysoftware_path = os.getenv("MYSOFTWARE")
 +    if _mysoftware_path is None:
 +        user_path =  ("~%s.spack" % os.sep)
 +    else:
 +        user_path = f"{_mysoftware_path}{os.sep}setonix{os.sep}.spack_user_config"
-+    return os.path.expanduser(user_path)
++    return user_path
++
++
+ # Below paths are where Spack can write information for the user.
+ # Some are caches, some are not exactly caches.
+ #
+@@ -85,7 +101,7 @@
+ # setting `SPACK_USER_CACHE_PATH`. Otherwise it defaults to ~/.spack.
+ #
+ def _get_user_cache_path():
+-    return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or "~%s.spack" % os.sep)
++    return os.path.expanduser(os.getenv("SPACK_USER_CACHE_PATH") or _get_pawsey_custom_path())
+ 
+ 
+ user_cache_path = _get_user_cache_path()
+@@ -120,7 +136,7 @@ def _get_user_cache_path():
+ 
+ # User configuration and caches in $HOME/.spack
+ def _get_user_config_path():
+-    return os.path.expanduser(os.getenv("SPACK_USER_CONFIG_PATH") or "~%s.spack" % os.sep)
++    return os.path.expanduser(_get_pawsey_custom_path())
  
  
  # Configuration in /etc/spack on the system

--- a/systems/setonix/configs/site/bootstrap.yaml
+++ b/systems/setonix/configs/site/bootstrap.yaml
@@ -1,0 +1,3 @@
+bootstrap:
+  root: BOOTSTRAP_PATH 
+

--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -3,7 +3,7 @@ if [ -z ${__PSC_SETTINGS__+x} ]; then # include guard
 __PSC_SETTINGS__=1
 
 # EDIT at each rebuild of the software stack
-DATE_TAG="2023.01"
+DATE_TAG="2023.02"
 
 if [ -z ${INSTALL_PREFIX+x} ]; then
     INSTALL_PREFIX="/software/setonix/${DATE_TAG}"
@@ -36,6 +36,8 @@ fi
 # Note the use of '' instead of "" to allow env variables to be present in config files
 USER_PERMANENT_FILES_PREFIX='/software/projects'
 USER_TEMP_FILES_PREFIX='/scratch'
+SPACK_USER_CONFIG_PATH="$MYSOFTWARE/setonix/.spack_user_config"
+BOOTSTRAP_PATH='$MYSOFTWARE/setonix/.spack_user_config/bootstrap'
 
 pawseyenv_version="${DATE_TAG}"
 


### PR DESCRIPTION
This will avoid hitting the /home quota, and will allow the user to have a different spack cache for each project. But most importantly, it will allow us to parametrise the user configuration path (a.k.a ~/.spack) based on the software stack version.

Opening this merge request for you to review the strategy, do not merge yet, more testing is needed.