### PR TITLE
Adds DATE_TAG to user and project directory hierarchies.

### DIFF
--- a/fixes/dot_spack.patch
+++ b/fixes/dot_spack.patch
@@ -18,7 +18,7 @@ index fc617342e8..885f00081a 100644
 +    if _mysoftware_path is None:
 +        user_path =  ("~%s.spack" % os.sep)
 +    else:
-+        user_path = f"{_mysoftware_path}{os.sep}setonix{os.sep}.spack_user_config"
++        user_path = f"{_mysoftware_path}{os.sep}PAWSEY_SYSTEM{os.sep}DATE_TAG{os.sep}.spack_user_config"
 +    return user_path
 +
 +

--- a/scripts/install_shpc.sh
+++ b/scripts/install_shpc.sh
@@ -77,16 +77,16 @@ shpc config set container_tech:singularity
 shpc config remove registry:\$root_dir/registry
 shpc config add "registry:${INSTALL_PREFIX}/${shpc_install_dir}/registry"
 shpc config add "registry:${INSTALL_PREFIX}/${shpc_install_dir}/pawsey_registry"
-shpc config add "registry:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/shpc_registry"
+shpc config add "registry:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/$DATE_TAG/shpc_registry"
 # user install location for modulefiles
-shpc config set "module_base:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/${shpc_containers_modules_dir_long}"
+shpc config set "module_base:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/$DATE_TAG/${shpc_containers_modules_dir_long}"
 # disable default version for modulefiles (original)
 shpc config set default_version:null
 # user install location for containers
-shpc config set "container_base:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/${shpc_containers_dir}"
+shpc config set "container_base:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/$DATE_TAG/${shpc_containers_dir}"
 # user install location for modulefiles (symlinks - views)
 # variable substitutions assume format like views/modules
-shpc config set "views_base:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/${shpc_containers_modules_dir%/*}"
+shpc config set "views_base:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/$DATE_TAG/${shpc_containers_modules_dir%/*}"
 shpc config set "default_view:${shpc_containers_modules_dir##*/}"
 # singularity module
 shpc config set "singularity_module:${singularity_name}/${singularity_version}"
@@ -97,7 +97,7 @@ shpc config set wrapper_scripts:enabled:true
 # enable X11 graphics
 shpc config set container_features:x11:true
 # location for container fake home
-shpc config set "container_features:home:\$MYSOFTWARE/.${shpc_name}_home"
+shpc config set "container_features:home:\$MYSOFTWARE/setonix/$DATE_TAG/.${shpc_name}_home"
 
 ## SPACK USER (system wide installation)
 shpc config inituser

--- a/scripts/install_spack.sh
+++ b/scripts/install_spack.sh
@@ -68,6 +68,7 @@ cp -r ${PAWSEY_SPACK_CONFIG_REPO}/systems/${SYSTEM}/templates/* "${INSTALL_PREFI
 # and finally customise them with the actual software stack installation path.
 sed -i \
   -e "s|INSTALL_PREFIX|${INSTALL_PREFIX}|g" \
+  -e "s|DATE_TAG|$DATE_TAG|g"\
   -e "s|USER_PERMANENT_FILES_PREFIX|${USER_PERMANENT_FILES_PREFIX}|g"\
   -e "s|USER_TEMP_FILES_PREFIX|${USER_TEMP_FILES_PREFIX}|g"\
   -e "s|BOOTSTRAP_PATH|${BOOTSTRAP_PATH}|g"\
@@ -85,6 +86,7 @@ sed \
   -e "s;CCE_VERSION;${cce_version};g" \
   -e "s;PROJECT_MODULES_SUFFIX;${project_modules_suffix};g" \
   -e "s;USER_MODULES_SUFFIX;${user_modules_suffix};g" \
+  -e "s|DATE_TAG|$DATE_TAG|g"\
   -e "s;SHPC_CONTAINERS_MODULES_DIR;${shpc_containers_modules_dir};g" \
   -e "s;R_VERSION_MAJORMINOR;${r_version_majorminor};g" \
   -e "s|USER_PERMANENT_FILES_PREFIX|${USER_PERMANENT_FILES_PREFIX}|g"\
@@ -112,6 +114,7 @@ chmod a+rx \
 mkdir -p ${INSTALL_PREFIX}/${spack_module_dir}
 sed \
   -e "s|INSTALL_PREFIX|${INSTALL_PREFIX}|g"\
+  -e "s|DATE_TAG|$DATE_TAG|g"\
   -e "s|USER_PERMANENT_FILES_PREFIX|${USER_PERMANENT_FILES_PREFIX}|g"\
   -e "s/SPACK_VERSION/${spack_version}/g" \
   -e "s/PYTHON_MODULEFILE/${python_name}\/${python_version}/g" \
@@ -139,6 +142,7 @@ done
 
 sed \
   -e "s|INSTALL_PREFIX|${INSTALL_PREFIX}|g"\
+  -e "s|DATE_TAG|$DATE_TAG|g"\
   -e "s|USER_PERMANENT_FILES_PREFIX|${USER_PERMANENT_FILES_PREFIX}|g"\
   -e "s;CUSTOM_MODULES_DIR;${custom_modules_dir};g" \
   -e "s;UTILITIES_MODULES_DIR;${utilities_modules_dir};g" \

--- a/scripts/install_spack.sh
+++ b/scripts/install_spack.sh
@@ -29,6 +29,9 @@ if ! [ -e ${INSTALL_PREFIX}/spack ]; then
   cd "${INSTALL_PREFIX}/spack"
   git checkout v${spack_version}
 
+  sed -i -e "s|DATE_TAG|$DATE_TAG|g"\
+    -e "s|PAWSEY_SYSTEM|$SYSTEM|g"\
+    ${PAWSEY_SPACK_CONFIG_REPO}/fixes/dot_spack.patch
   # apply Marco's LMOD fixes into spack tree
   patch ${INSTALL_PREFIX}/spack/lib/spack/spack/modules/lmod.py \
     ${PAWSEY_SPACK_CONFIG_REPO}/fixes/lmod_arch_family.patch

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -59,19 +59,19 @@ end
 -- Add User modules to Cray Lmod hierarchy variables
 -- Compiler modulefiles: /opt/cray/pe/lmod/modulefiles/core/<compiler>/<version>.lua
 -- Cray service functions: /opt/cray/pe/admin-pe/lmod_scripts/lmodHierarchy.lua
-local psc_sw_env_user_modules_root =  "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/" .. psc_sw_env_user .. "/setonix/modules/" .. arch
+local psc_sw_env_user_modules_root =  "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/" .. psc_sw_env_user .. "/setonix/DATE_TAG/modules/" .. arch
 prepend_path("LMOD_CUSTOM_COMPILER_GNU_8_0_PREFIX", psc_sw_env_user_modules_root .. "/gcc/" .. psc_sw_env_gcc_version .. "/" .. psc_sw_env_user_modules_suffix)
 prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_14_0_PREFIX", psc_sw_env_user_modules_root .. "/cce/" .. psc_sw_env_cce_version .. "/" .. psc_sw_env_user_modules_suffix)
 prepend_path("LMOD_CUSTOM_COMPILER_AOCC_3_0_PREFIX", psc_sw_env_user_modules_root .. "/aocc/" .. psc_sw_env_aocc_version .. "/" .. psc_sw_env_user_modules_suffix)
 
 
 -- Add User SHPC modules to MODULEPATH
-local psc_sw_env_shpc_user_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/" .. psc_sw_env_user .. "/setonix/" .. psc_sw_env_shpc_containers_modules_dir
+local psc_sw_env_shpc_user_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/" .. psc_sw_env_user .. "/setonix/DATE_TAG/" .. psc_sw_env_shpc_containers_modules_dir
 prepend_path("MODULEPATH", psc_sw_env_shpc_user_root)
 
 
 -- Add Project modules to Cray Lmod hierarchy variables
-local psc_sw_env_project_modules_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/setonix/modules/" .. arch
+local psc_sw_env_project_modules_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/setonix/DATE_TAG/modules/" .. arch
 prepend_path("LMOD_CUSTOM_COMPILER_GNU_8_0_PREFIX", psc_sw_env_project_modules_root .. "/gcc/" .. psc_sw_env_gcc_version .. "/" .. psc_sw_env_project_modules_suffix)
 prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_14_0_PREFIX", psc_sw_env_project_modules_root .. "/cce/" .. psc_sw_env_cce_version .. "/" .. psc_sw_env_project_modules_suffix)
 prepend_path("LMOD_CUSTOM_COMPILER_AOCC_3_0_PREFIX", psc_sw_env_project_modules_root .. "/aocc/" .. psc_sw_env_aocc_version .. "/" .. psc_sw_env_project_modules_suffix)

--- a/scripts/templates/spack.lua
+++ b/scripts/templates/spack.lua
@@ -17,7 +17,7 @@ local user = os.getenv("USER")
 if ( user == "spack" ) then
   setenv("SPACK_LOGS_BASEDIR", "INSTALL_PREFIX/software/" .. user .. "/logs")
 else
-  setenv("SPACK_LOGS_BASEDIR", "USER_PERMANENT_FILES_PREFIX/" .. os.getenv("PAWSEY_PROJECT") .. "/" .. user .. "/setonix/software/" .. user .. "/logs")
+  setenv("SPACK_LOGS_BASEDIR", "USER_PERMANENT_FILES_PREFIX/" .. os.getenv("PAWSEY_PROJECT") .. "/" .. user .. "/setonix/DATE_TAG/software/" .. user .. "/logs")
 end
 
 -- Lmod 8.6+ has a function to source shell files in an unloadable way

--- a/scripts/templates/spack_create_user_moduletree.sh
+++ b/scripts/templates/spack_create_user_moduletree.sh
@@ -12,8 +12,8 @@ r_version_majorminor="R_VERSION_MAJORMINOR"
 
 # for user and project directories, give option to provide project via CLI
 tree_project="${1:-$PAWSEY_PROJECT}"
-project_root_dir="USER_PERMANENT_FILES_PREFIX/${tree_project}/setonix"
-user_root_dir="USER_PERMANENT_FILES_PREFIX/${tree_project}/${USER}/setonix"
+project_root_dir="USER_PERMANENT_FILES_PREFIX/${tree_project}/setonix/DATE_TAG"
+user_root_dir="USER_PERMANENT_FILES_PREFIX/${tree_project}/${USER}/setonix/DATE_TAG"
 
 archs="zen3 zen2"
 compilers="gcc/${gcc_version} aocc/${aocc_version} cce/${cce_version}"

--- a/systems/setonix/configs/project/config.yaml
+++ b/systems/setonix/configs/project/config.yaml
@@ -2,4 +2,4 @@
 
 config:
   install_tree:
-    root: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/software
+    root: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG/software

--- a/systems/setonix/configs/project/modules.yaml
+++ b/systems/setonix/configs/project/modules.yaml
@@ -3,4 +3,4 @@
 modules:
   default:
     roots:
-      lmod: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/modules
+      lmod: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG/modules

--- a/systems/setonix/configs/site/config.yaml
+++ b/systems/setonix/configs/site/config.yaml
@@ -2,7 +2,7 @@ config:
 
   # This is the path to the root of the Spack install tree.
   install_tree:
-    root: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/software
+    root: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/software
 
   # Locations where templates should be found
   template_dirs:
@@ -36,21 +36,21 @@ config:
   # `spack clean -a`, so it is important that the specified directory uniquely
   # identifies Spack staging to avoid accidentally wiping out non-Spack work.
   build_stage:
-    - USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/software/$USER/build_stage
+    - USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/software/$USER/build_stage
 
   # Directory in which to run tests and store test results.
   # Tests will be stored in directories named by date/time and package
   # name/hash.
-  test_stage: USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/software/$USER/test_stage
+  test_stage: USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/software/$USER/test_stage
 
   # Cache directory for already downloaded source tarballs and archived
   # repositories. This can be purged with `spack clean --downloads`.
-  source_cache: USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/software/$USER/source_cache
+  source_cache: USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/software/$USER/source_cache
 
 
   # Cache directory for miscellaneous files, like the package index.
   # This can be purged with `spack clean --misc-cache`
-  misc_cache: USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/software/$USER/misc_cache
+  misc_cache: USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/software/$USER/misc_cache
 
   # concretizer: `clingo` or `original` (good for debugging concretisations)
   concretizer: clingo

--- a/systems/setonix/configs/site/modules.yaml
+++ b/systems/setonix/configs/site/modules.yaml
@@ -20,7 +20,7 @@ modules:
     enable::
       - lmod 
     roots:
-      lmod: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/modules
+      lmod: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/modules
     lmod:
       # set the hierarchy. Typical start point is mpi 
       # however, since there will only be a single 

--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -36,8 +36,8 @@ fi
 # Note the use of '' instead of "" to allow env variables to be present in config files
 USER_PERMANENT_FILES_PREFIX='/software/projects'
 USER_TEMP_FILES_PREFIX='/scratch'
-SPACK_USER_CONFIG_PATH="$MYSOFTWARE/setonix/.spack_user_config"
-BOOTSTRAP_PATH='$MYSOFTWARE/setonix/.spack_user_config/bootstrap'
+SPACK_USER_CONFIG_PATH="$MYSOFTWARE/setonix/$DATE_TAG/.spack_user_config"
+BOOTSTRAP_PATH='$MYSOFTWARE/setonix/'$DATE_TAG/.spack_user_config/bootstrap
 
 pawseyenv_version="${DATE_TAG}"
 


### PR DESCRIPTION
We are going to version user and project-wide installations. The reasons:

1. Spack user cache of different Spack and software stack deployments must be kept separate, otherwise, there is the risk of installing software in the wrong location.
2. By default, we do not want a user's and project's software stack to depend on a mix of Pawsey stack deployments, for instance starting to install with dependencies in 2022.11 and then moving to 2023.02 after the latter is deployed. This will make it easier to get rid of older software stacks and identify affected users.
3. Spack recipes may not be compatible across Spack versions.

And other reasons I am sure are out there waiting to be found.

Not to merge yet, needs to be tested.