### PR TITLE
Implements build cache.

### DIFF
--- a/scripts/install_environments.sh
+++ b/scripts/install_environments.sh
@@ -58,6 +58,10 @@ for env in $env_list; do
   cd -
 done
 
+# Create binary cache
+if [ ${SPACK_POPULATE_CACHE} -eq 1 ]; then
+  for hash in `spack find -x --format "{hash}"`; do spack buildcache create -a -m systemwide_buildcache  /$hash; done;
+fi
 # Refresh module files
 for hash in `spack find -x --format "{hash}"`; do spack module lmod refresh -y /$hash; done;
 

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -18,6 +18,14 @@ module load cray-python
 # initialise spack 
 . "${INSTALL_PREFIX}/spack/share/spack/setup-env.sh"
 
+# Initialise GPG keys to sign build cache
+# This needs to be run on compute nodes seems like.
+spack gpg init
+spack gpg create Cristian cdipietrantonio@pawsey.org.au
+
+# Create/add mirror
+spack mirror add systemwide_buildcache "${SPACK_BUILDCACHE_PATH}"
+
 # make sure Clingo is bootstrapped
 echo "Running 'spack -d spec nano' to bootstrap Clingo.."
 spack -d spec nano

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -21,7 +21,7 @@ module load cray-python
 # Initialise GPG keys to sign build cache
 # This needs to be run on compute nodes seems like.
 spack gpg init
-spack gpg create Cristian cdipietrantonio@pawsey.org.au
+spack gpg create Spack spack@pawsey.org.au
 
 # Create/add mirror
 spack mirror add systemwide_buildcache "${SPACK_BUILDCACHE_PATH}"

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -20,11 +20,13 @@ module load cray-python
 
 # Initialise GPG keys to sign build cache
 # This needs to be run on login nodes seems like.
-spack gpg init
-spack gpg create Spack spack@pawsey.org.au
+if [ ${SPACK_POPULATE_CACHE} -eq 1 ]; then
+    spack gpg init
+    spack gpg create Spack spack@pawsey.org.au
 
-# Create/add mirror
-spack mirror add systemwide_buildcache "${SPACK_BUILDCACHE_PATH}"
+    # Create/add mirror
+    spack mirror add systemwide_buildcache "${SPACK_BUILDCACHE_PATH}"
+fi
 
 # make sure Clingo is bootstrapped
 echo "Running 'spack -d spec nano' to bootstrap Clingo.."

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -19,7 +19,7 @@ module load cray-python
 . "${INSTALL_PREFIX}/spack/share/spack/setup-env.sh"
 
 # Initialise GPG keys to sign build cache
-# This needs to be run on compute nodes seems like.
+# This needs to be run on login nodes seems like.
 spack gpg init
 spack gpg create Spack spack@pawsey.org.au
 

--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -38,6 +38,12 @@ USER_PERMANENT_FILES_PREFIX='/software/projects'
 USER_TEMP_FILES_PREFIX='/scratch'
 SPACK_USER_CONFIG_PATH="$MYSOFTWARE/setonix/$DATE_TAG/.spack_user_config"
 BOOTSTRAP_PATH='$MYSOFTWARE/setonix/'$DATE_TAG/.spack_user_config/bootstrap
+# Set a new mirror where to fetch prebuilt binaries, if any.
+SPACK_BUILDCACHE_PATH=${INSTALL_PREFIX}/build_cache
+# When SPACK_POPULATE_CACHE=1, spack will push binaries in the above cache location for later use.
+# The operation will be executed after having installed the environments.
+# Useful when building the stack on the test system.
+SPACK_POPULATE_CACHE=0
 
 pawseyenv_version="${DATE_TAG}"
 


### PR DESCRIPTION
As per the title, implements the build cache system. Unfortunately it seems that `gpg` does not run well on compute nodes, hence `gpg create` needs to run on login node (unless it gets fixed).