### PR TITLE
Adds `ncl` and `feh` to the Pawsey provided software.

### DIFF
--- a/systems/setonix/configs/spackuser/modules.yaml
+++ b/systems/setonix/configs/spackuser/modules.yaml
@@ -134,6 +134,7 @@ modules:
         openfoam: 'applications/{name}/{version}'
         # This other flavour of openfoam will be kept blocked until bare-metal install is tested
         #openfoam-org: 'applications/{name}/{version}'
+        ncl: 'applications/{name}/{version}' 
         quantum-espresso: 'applications/{name}/{version}'
         "vasp@6": 'applications/{name}6/{version}'
         vasp: 'applications/{name}/{version}'

--- a/systems/setonix/configs/spackuser/modules.yaml
+++ b/systems/setonix/configs/spackuser/modules.yaml
@@ -243,7 +243,8 @@ modules:
         tower-agent: 'utilities/{name}/{version}'
         tower-cli: 'utilities/{name}/{version}'
         mpifileutils: 'utilities/{name}/{version}'
-
+        feh: 'utilities/{name}/{version}'
+             
         # S3 clients 
         awscli: 'utilities/{name}/{version}'
         py-boto3: 'utilities/{name}/{version}'

--- a/systems/setonix/environments/apps/spack.yaml
+++ b/systems/setonix/environments/apps/spack.yaml
@@ -39,7 +39,7 @@ spack:
 # Failing:    - openfoam-org@8 #Alexis still working on it
 # Current alternative:
     - openfoam@2206
-
+    - ncl@6.6.2 ^esmf ~mpi
   - packages-with-oldpython:
     - nwchem@7.2.0 +fftw3 +openmp ^python@3.9.15
 


### PR DESCRIPTION
Hi guys, I propose to add two new software packages to our system-wide stack:
- `feh`, to render images on Setonix using X11 forwarding. It provides users an easy way to open `jpeg`, `png`, and other formats.
- `ncl` is a package used by environmental scientists and has been requested on a number of tickets (see #182).

EDIT:
the `~mpi` variant in the spec of `esmf` comes from the following error

```
  >> 5268    /usr/bin/ld: cannot find -lmpi++: No such file or directory
  >> 5269    collect2: error: ld returned 1 exit status
  >> 5270    make[2]: *** [makefile:35: tracelib_preload] Error 1

```