### PR TITLE
A spack wrapper to provide single command to handle user and project installations

### DIFF
--- a/scripts/install_spack.sh
+++ b/scripts/install_spack.sh
@@ -98,17 +98,18 @@ cp ${PAWSEY_SPACK_CONFIG_REPO}/scripts/templates/spack_refresh_modules.sh \
    ${PAWSEY_SPACK_CONFIG_REPO}/scripts/templates/spack_rm_modules.sh \
    ${INSTALL_PREFIX}/spack/bin/
 
-# spack_project.sh: install a software for the entire project.
+# Install a spack wrapper to handle project installations
+mv ${INSTALL_PREFIX}/spack/bin/spack ${INSTALL_PREFIX}/spack/bin/realspack
 sed \
   -e "s;INSTALL_PREFIX;${INSTALL_PREFIX};g" \
-  ${PAWSEY_SPACK_CONFIG_REPO}/scripts/templates/spack_project.sh \
-  >${INSTALL_PREFIX}/spack/bin/spack_project.sh
+  ${PAWSEY_SPACK_CONFIG_REPO}/scripts/templates/spack \
+  >${INSTALL_PREFIX}/spack/bin/spack
 
 chmod a+rx \
   ${INSTALL_PREFIX}/spack/bin/spack_create_user_moduletree.sh \
   ${INSTALL_PREFIX}/spack/bin/spack_refresh_modules.sh \
   ${INSTALL_PREFIX}/spack/bin/spack_rm_modules.sh \
-  ${INSTALL_PREFIX}/spack/bin/spack_project.sh
+  ${INSTALL_PREFIX}/spack/bin/spack
 
 # edit and copy over Spack modulefile
 mkdir -p ${INSTALL_PREFIX}/${spack_module_dir}

--- a/scripts/templates/spack
+++ b/scripts/templates/spack
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SPACK_DIR=INSTALL_PREFIX/spack
+REALSPACK="${SPACK_DIR}/bin/realspack"
+
+if (( $# > 0 )) && [ "$1" = "project" ]; then
+    # enable group access and writing to the stack
+    umask g+rwx
+    ${REALSPACK} -C "${SPACK_DIR}/etc/spack/project" ${@:2}
+else
+    ${REALSPACK} ${@}
+fi
+

--- a/scripts/templates/spack_project.sh
+++ b/scripts/templates/spack_project.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# enable group access and writing to the stack
-umask g+rwx
-
-# use spack configs for project-wide setup
-spack -C INSTALL_PREFIX/spack/etc/spack/project $@


### PR DESCRIPTION
Instead of having two executables, `spack` and `spack_project.sh`, we should have a single `spack` command with a `project` subcommand to handle project installations. The proposed solution provides a cleaner interface to users.