### PR TITLE
adding installation script for omniperf

### DIFF
--- a/repo/packages/blaspp/package.py
+++ b/repo/packages/blaspp/package.py
@@ -1,0 +1,98 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+
+class Blaspp(CMakePackage, CudaPackage, ROCmPackage):
+    """C++ API for the Basic Linear Algebra Subroutines. Developed by the
+    Innovative Computing Laboratory at the University of Tennessee,
+    Knoxville."""
+
+    homepage = "https://github.com/icl-utk-edu/blaspp"
+    git = homepage
+    url = "https://github.com/icl-utk-edu/blaspp/releases/download/v2023.01.00/blaspp-2023.01.00.tar.gz"
+    maintainers = ["teonnik", "Sely85", "G-Ragghianti", "mgates3"]
+
+    version("master", branch="master")
+    version(
+        "2023.08.25", sha256="1d9c7227a6d8776944aa866592142b7b51c6e4ba5529d168eb8ae2b329c47401"
+    )
+    version(
+        "2023.06.00", sha256="e261ad6cde2aa4f97e985aa9067f4c40d2aaa856904bb78007a3dcadf1378ae9"
+    )
+    version(
+        "2022.07.00", sha256="566bd644f0364caffde6669e0f86514658eb06ca3d252a4fe67203921a875481"
+    )
+    version(
+        "2022.05.00", sha256="696277859bc1bd9c0aeb0cb170a1e259765c0a86af49b20afa0ffcbabc3e207e"
+    )
+    version(
+        "2021.04.01", sha256="11fc7b7e725086532ada58c0de53f30e480c2a06f1497b8081ea6d8f97e26150"
+    )
+    version(
+        "2020.10.02", sha256="36e45bb5a8793ba5d7bc7c34fc263f91f92b0946634682937041221a6bf1a150"
+    )
+    version(
+        "2020.10.01", sha256="1a05dbc46caf797d59a7c189216b876fdb1b2ff3e2eb48f1e6ca4b2756c59153"
+    )
+    version(
+        "2020.10.00", sha256="ce148cfe397428d507c72d7d9eba5e9d3f55ad4cd842e6e873c670183dcb7795"
+    )
+
+    variant("openmp", default=True, description="Use OpenMP internally.")
+    variant("shared", default=True, description="Build shared libraries")
+
+    depends_on("cmake@3.15.0:", type="build")
+    depends_on("blas")
+    depends_on("llvm-openmp", when="%apple-clang +openmp")
+    depends_on("rocblas", when="+rocm")
+
+    # only supported with clingo solver: virtual dependency preferences
+    # depends_on('openblas threads=openmp', when='+openmp ^openblas')
+
+    # BLAS++ tests will fail when using openblas > 0.3.5 without multithreading support
+    # locking is only supported in openblas 3.7+
+    conflicts("^openblas@0.3.6 threads=none", msg="BLAS++ requires a threadsafe openblas")
+    conflicts("^openblas@0.3.7: ~locking", msg="BLAS++ requires a threadsafe openblas")
+
+    conflicts(
+        "+rocm", when="@:2020.10.02", msg="ROCm support requires BLAS++ 2021.04.00 or greater"
+    )
+    conflicts("+rocm", when="+cuda", msg="BLAS++ can only support one GPU backend at a time")
+
+    def cmake_args(self):
+        spec = self.spec
+        backend_config = "-Duse_cuda=%s" % ("+cuda" in spec)
+        if self.version >= Version("2021.04.01"):
+            backend = "none"
+            if "+cuda" in spec:
+                backend = "cuda"
+            if "+rocm" in spec:
+                backend = "hip"
+            backend_config = "-Dgpu_backend=%s" % backend
+
+        args = [
+            "-Dbuild_tests=%s" % self.run_tests,
+            "-Duse_openmp=%s" % ("+openmp" in spec),
+            "-DBUILD_SHARED_LIBS=%s" % ("+shared" in spec),
+            backend_config,
+            "-DBLAS_LIBRARIES=%s" % spec["blas"].libs.joined(";"),
+        ]
+
+        if spec["blas"].name == "cray-libsci":
+            args.append(self.define("BLA_VENDOR", "CRAY"))
+
+        return args
+
+    def check(self):
+        # If the tester fails to build, ensure that the check() fails.
+        if os.path.isfile(join_path(self.builder.build_directory, "test", "tester")):
+            with working_dir(self.builder.build_directory):
+                make("check")
+        else:
+            raise Exception("The tester was not built!")

--- a/repo/packages/lapackpp/package.py
+++ b/repo/packages/lapackpp/package.py
@@ -1,0 +1,113 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.package import *
+
+# Each LAPACK++ version requires a specific BLAS++ version
+_versions = [
+    # LAPACK++,     BLAS++
+    ["master", "master"],
+    ["2023.08.25", "2023.08.25"],
+    ["2023.06.00", "2023.06.00"],
+    ["2022.07.00", "2022.07.00"],
+    ["2022.05.00", "2022.05.00"],
+    ["2020.10.00", "2020.10.00"],
+    ["2020.10.01", "2020.10.01"],
+    ["2020.10.02", "2020.10.02"],
+    ["2021.04.00", "2021.04.01:"],  # or later
+]
+
+
+class Lapackpp(CMakePackage, CudaPackage, ROCmPackage):
+    """LAPACK++: C++ API for the LAPACK Linear Algebra Package. Developed
+    by the Innovative Computing Laboratory at the University of Tennessee,
+    Knoxville."""
+
+    homepage = "https://github.com/icl-utk-edu/lapackpp"
+    git = homepage
+    url = "https://github.com/icl-utk-edu/lapackpp/releases/download/v2023.01.00/lapackpp-2023.01.00.tar.gz"
+    maintainers = ["teonnik", "Sely85", "G-Ragghianti", "mgates3"]
+
+    version("master", branch="master")
+    version(
+        "2023.08.25", sha256="9effdd616a4a183a9b37c2ad33c85ddd3d6071b183e8c35e02243fbaa7333d4d"
+    )
+    version(
+        "2023.06.00", sha256="93df8392c859071120e00239feb96a0e060c0bb5176ee3a4f03eb9777c4edead"
+    )
+    version(
+        "2022.07.00", sha256="11e59efcc7ea0764a2bfc0e0f7b1abf73cee2943c1df11a19601780641a9aa18"
+    )
+    version(
+        "2022.05.00", sha256="d0f548cbc9d4ac46b1f961834d113173c0b433074f77bcfd69c7c31cb89b7ff2"
+    )
+    version(
+        "2021.04.00", sha256="67abd8de9757dba86eb5d154cdb91f176b6c8b2b7d8e2a669ba0c221c4bb60ed"
+    )
+    version(
+        "2020.10.02", sha256="8dde9b95d75b494c4f8b893d68034e95b7a7541981359acb97b6c1c4a9c45cd9"
+    )
+    version(
+        "2020.10.01", sha256="ecd659730b4c3cfb8d2595f9bbb6af65d96b79397db654f17fe045bdfea841c0"
+    )
+    version(
+        "2020.10.00", sha256="5f6ab3bd3794711818a3a50198efd29571520bf455e13ffa8ba50fa8376d7d1a"
+    )
+
+    variant("shared", default=True, description="Build shared library")
+
+    # Match each LAPACK++ version to a specific BLAS++ version
+    for lpp_ver, bpp_ver in _versions:
+        depends_on("blaspp@" + bpp_ver, when="@" + lpp_ver)
+
+    depends_on("blaspp ~cuda", when="~cuda")
+    depends_on("blaspp +cuda", when="+cuda")
+    depends_on("blaspp ~rocm", when="~rocm")
+    for val in ROCmPackage.amdgpu_targets:
+        depends_on("blaspp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
+
+    depends_on("blas")
+    depends_on("lapack")
+    depends_on("rocblas", when="+rocm")
+    depends_on("rocsolver", when="+rocm")
+
+    conflicts("+rocm", when="+cuda", msg="LAPACK++ can only support one GPU backend at a time")
+
+    def cmake_args(self):
+        spec = self.spec
+
+        backend = "none"
+        if self.version >= Version("2022.07.00"):
+            if "+cuda" in spec:
+                backend = "cuda"
+            if "+rocm" in spec:
+                backend = "hip"
+
+        args = [
+            "-DBUILD_SHARED_LIBS=%s" % ("+shared" in spec),
+            "-Dbuild_tests=%s" % self.run_tests,
+            "-DLAPACK_LIBRARIES=%s" % spec["lapack"].libs.joined(";"),
+            "-Dgpu_backend=%s" % backend,
+        ]
+
+        if spec["blas"].name == "cray-libsci":
+            args.append(self.define("BLA_VENDOR", "CRAY"))
+
+        return args
+
+    def check(self):
+        # If the tester fails to build, ensure that the check() fails.
+        if os.path.isfile(join_path(self.builder.build_directory, "test", "tester")):
+            with working_dir(self.builder.build_directory):
+                make("check")
+        else:
+            raise Exception("The tester was not built!")
+
+    def flag_handler(self, name, flags):
+        if (self.spec["blas"].name == "cray-libsci") and name == "cxxflags":
+            flags.append("-DLAPACK_FORTRAN_ADD_")
+        return (None, None, flags)

--- a/repo/packages/slate/package.py
+++ b/repo/packages/slate/package.py
@@ -1,0 +1,156 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Slate(CMakePackage, CudaPackage, ROCmPackage):
+    """The Software for Linear Algebra Targeting Exascale (SLATE) project is
+    to provide fundamental dense linear algebra capabilities to the US
+    Department of Energy and to the high-performance computing (HPC) community
+    at large. To this end, SLATE will provide basic dense matrix operations
+    (e.g., matrix multiplication, rank-k update, triangular solve), linear
+    systems solvers, least square solvers, singular value and eigenvalue
+    solvers."""
+
+    homepage = "https://icl.utk.edu/slate/"
+    git = "https://github.com/icl-utk-edu/slate"
+    url = "https://github.com/icl-utk-edu/slate/releases/download/v2022.07.00/slate-2022.07.00.tar.gz"
+    maintainers = ["G-Ragghianti", "mgates3"]
+
+    tags = ["e4s"]
+    test_requires_compiler = True
+
+    version("master", branch="master")
+    version(
+        "2023.08.25", sha256="0894d8669ed88358cc7c4cb7b77d8467336613245a7b843f3504e9224632ce0e"
+    )
+    version(
+        "2022.07.00", sha256="176db81aef44b1d498a37c67b30aff88d4025770c9200e19ceebd416e4101327"
+    )
+    version(
+        "2022.06.00", sha256="4da23f3c3c51fde65120f80df2b2f703aee1910389c08f971804aa77d11ac027"
+    )
+    version(
+        "2022.05.00", sha256="960f61ec2a4e1fa5504e3e4bdd8f62e607936f27a8fd66f340d15119706df588"
+    )
+    version(
+        "2021.05.02", sha256="29667a9e869e41fbc22af1ae2bcd425d79b4094bbb3f21c411888e7adc5d12e3"
+    )
+    version(
+        "2021.05.01", sha256="d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218"
+    )
+    version(
+        "2020.10.00", sha256="ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab"
+    )
+
+    variant(
+        "mpi", default=True, description="Build with MPI support (without MPI is experimental)."
+    )
+    variant("openmp", default=True, description="Build with OpenMP support.")
+    variant("shared", default=True, description="Build shared library")
+
+    # The runtime dependency on cmake is needed by the stand-alone tests (spack test).
+    depends_on("cmake", type="run")
+
+    depends_on("mpi", when="+mpi")
+    depends_on("blas")
+    depends_on("blaspp ~cuda", when="~cuda")
+    depends_on("blaspp +cuda", when="+cuda")
+    depends_on("blaspp ~rocm", when="~rocm")
+    depends_on("lapackpp ~cuda", when="~cuda")
+    depends_on("lapackpp +cuda", when="+cuda")
+    depends_on("lapackpp ~rocm", when="~rocm")
+    for val in CudaPackage.cuda_arch_values:
+        depends_on("blaspp +cuda cuda_arch=%s" % val, when="cuda_arch=%s" % val)
+        depends_on("lapackpp +cuda cuda_arch=%s" % val, when="cuda_arch=%s" % val)
+    for val in ROCmPackage.amdgpu_targets:
+        depends_on("blaspp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
+        depends_on("lapackpp +rocm amdgpu_target=%s" % val, when="amdgpu_target=%s" % val)
+    depends_on("lapackpp@2023.08.25:", when="@2023.08.25:")
+    depends_on("lapackpp@2022.07.00:", when="@2022.07.00:")
+    depends_on("lapackpp@2022.05.00:", when="@2022.05.00:")
+    depends_on("lapackpp@2021.04.00:", when="@2021.05.01:")
+    depends_on("lapackpp@2020.10.02", when="@2020.10.00")
+    depends_on("lapackpp@master", when="@master")
+    depends_on("scalapack", type="test")
+    depends_on("hipify-clang", when="@:2021.05.02 +rocm ^hip@5:")
+
+    cpp_17_msg = "Requires C++17 compiler support"
+    conflicts("%gcc@:5", msg=cpp_17_msg)
+    conflicts("%xl", msg=cpp_17_msg)
+    conflicts("%xl_r", msg=cpp_17_msg)
+    conflicts("%intel@19:", msg="Does not currently build with icpc >= 2019")
+    conflicts(
+        "+rocm", when="@:2020.10.00", msg="ROCm support requires SLATE 2021.05.01 or greater"
+    )
+    conflicts("+rocm", when="+cuda", msg="SLATE only supports one GPU backend at a time")
+
+    def cmake_args(self):
+        spec = self.spec
+        backend_config = "-Duse_cuda=%s" % ("+cuda" in spec)
+        if self.version >= Version("2021.05.01"):
+            backend = "none"
+            if "+cuda" in spec:
+                backend = "cuda"
+            if "+rocm" in spec:
+                backend = "hip"
+            backend_config = "-Dgpu_backend=%s" % backend
+
+        config = [
+            "-Dbuild_tests=%s" % self.run_tests,
+            "-Duse_openmp=%s" % ("+openmp" in spec),
+            "-DBUILD_SHARED_LIBS=%s" % ("+shared" in spec),
+            backend_config,
+            "-Duse_mpi=%s" % ("+mpi" in spec),
+        ]
+        if "+cuda" in spec:
+            archs = ";".join(spec.variants["cuda_arch"].value)
+            config.append("-DCMAKE_CUDA_ARCHITECTURES=%s" % archs)
+        if "+rocm" in spec:
+            archs = ";".join(spec.variants["amdgpu_target"].value)
+            config.append("-DCMAKE_HIP_ARCHITECTURES=%s" % archs)
+
+        if self.run_tests:
+            config.append("-DSCALAPACK_LIBRARIES=%s" % spec["scalapack"].libs.joined(";"))
+        return config
+
+    @run_after("install")
+    def cache_test_sources(self):
+        if self.spec.satisfies("@2020.10.00"):
+            return
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources(["examples"])
+
+    def mpi_launcher(self):
+        searchpath = [self.spec["mpi"].prefix.bin]
+        try:
+            searchpath.insert(0, self.spec["slurm"].prefix.bin)
+        except KeyError:
+            print("Slurm not found, ignoring.")
+        commands = ["srun", "mpirun", "mpiexec"]
+        return which(*commands, path=searchpath) or which(*commands)
+
+    def test(self):
+        if self.spec.satisfies("@2020.10.00") or "+mpi" not in self.spec:
+            print("Skipping: stand-alone tests")
+            return
+
+        test_dir = join_path(self.test_suite.current_test_cache_dir, "examples", "build")
+        with working_dir(test_dir, create=True):
+            cmake_bin = join_path(self.spec["cmake"].prefix.bin, "cmake")
+            deps = "blaspp lapackpp mpi"
+            if self.spec.satisfies("+rocm"):
+                deps += " rocblas hip llvm-amdgpu comgr hsa-rocr-dev rocsolver"
+            prefixes = ";".join([self.spec[x].prefix for x in deps.split()])
+            self.run_test(cmake_bin, ["-DCMAKE_PREFIX_PATH=" + prefixes, ".."])
+            make()
+            test_args = ["-n", "4", "./ex05_blas"]
+            launcher = self.mpi_launcher()
+            if not launcher:
+                raise RuntimeError("Cannot run tests due to absence of MPI launcher")
+            self.run_test(launcher.command, test_args, purpose="SLATE smoke test")
+            make("clean")

--- a/systems/setonix/custom/omniperf.sh
+++ b/systems/setonix/custom/omniperf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-module load python/3.10.8 
-module load py-pip/22.2.2-py3.10.8
+module load python/3.10.10 
+module load py-pip/23.1.2-py3.10.10
 module load cmake/3.21.4
 wget https://github.com/AMDResearch/omniperf/releases/download/v1.0.6/omniperf-v1.0.6.tar.gz
 tar -xf omniperf-v1.0.6.tar.gz
@@ -20,4 +20,4 @@ cd ../..
 rm omniperf-v1.0.6.tar.gz
 rm -rf omniperf-1.0.6
 cd ${MODULE_DIR}/omniperf
-sed -i -e '$adepends_on("python/3.10.8")' 1.0.6.lua
+sed -i -e '$adepends_on("python/3.10.10")' 1.0.6.lua

--- a/systems/setonix/custom/omniperf.sh
+++ b/systems/setonix/custom/omniperf.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+module load python/3.10.8 
+module load py-pip/22.2.2-py3.10.8
+module load cmake/3.21.4
+wget https://github.com/AMDResearch/omniperf/releases/download/v1.0.6/omniperf-v1.0.6.tar.gz
+tar -xf omniperf-v1.0.6.tar.gz
+cd omniperf-1.0.6/
+cd src/
+sed -i 's/15.3/15.4/g' omniperf
+sed -i 's/15.3/15.4/g' common.py
+cd ..
+export INSTALL_DIR=/software/setonix/2023.08/custom/software/linux-sles15-zen3/gcc-12.2.0/omniperf/1.0.6
+export MODULE_DIR=/software/setonix/2023.08/custom/modules/zen3/gcc/12.2.0/custom
+python3 -m pip install -t ${INSTALL_DIR}/python-libs -r requirements.txt
+mkdir build
+cd build/
+cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/1.0.6 -DPYTHON_DEPS=${INSTALL_DIR}/python-libs -DMOD_INSTALL_PATH=${MODULE_DIR} ..
+make install
+cd ../..
+rm omniperf-v1.0.6.tar.gz
+rm -rf omniperf-1.0.6
+cd ${MODULE_DIR}/omniperf
+sed -i -e '$adepends_on("python/3.10.8")' 1.0.6.lua


### PR DESCRIPTION
Added installation script for omniperf:
Installation directory is set as 
/software/setonix/2023.08/custom/software/linux-sles15-zen3/gcc-12.2.0/omniperf/1.0.6
Module path is 
/software/setonix/2023.08/custom/modules/zen3/gcc/12.2.0/custom/omniperf/1.0.6.lua