### PR TITLE
Updating the HASH of shpc_registry_version

### DIFF
--- a/scripts/patch_shpc_pawsey_modules.sh
+++ b/scripts/patch_shpc_pawsey_modules.sh
@@ -25,10 +25,16 @@ of_dir="${INSTALL_PREFIX}/${containers_root_dir}/openfoam-sif"
 mkdir -p "${of_dir}"
 
 
-# Pawsey only - add -container suffix to tool directories
+# Pawsey only - move module files in ${tool} dirs to a directory with name ${tool}-container
+#  Contents are moved instead of renaming ${tool} dir in order to avoid nesting of directories when
+#   the ${tool}-container directory already exists
 for tool in "${short_dir}/openfoam" "${short_dir}/openfoam-org" "${short_dir}/hpc-python" ; do
   if [ -d ${tool} ] ; then
-    mv ${tool} ${tool}${shpc_spackuser_container_tag}
+    mkdir -p ${tool}${shpc_spackuser_container_tag}
+    for module in ${tool}/*.lua ; do
+      mv ${module} ${tool}${shpc_spackuser_container_tag}
+    done
+    rmdir $tool
   fi
 done
 

--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -61,7 +61,7 @@ spack_version="0.19.0" # the prefix "v" is added in setup_spack.sh
 singularity_version="3.11.4-nompi" # has to match the version in the Spack env yaml + nompi tag
 singularity_mpi_version="3.11.4-mpi" # has to match the version in the Spack env yaml + mpi tag
 shpc_version="0.1.23"
-shpc_registry_version="61a74214fb6d3b7667103cbaa022746fa931438d"
+shpc_registry_version="29f8f38f2afe562786ec0300c12d41c40f0efe97" #Hash for: Merge pull request #149 from PawseySC/alexis-dev
 
 # python (and py tools) versions
 python_name="python"
@@ -140,6 +140,8 @@ quay.io/pawsey/hpc-python:2022.03-hdf5mpi
 quay.io/pawsey/openfoam:v2212
 quay.io/pawsey/openfoam:v2206
 quay.io/pawsey/openfoam:v2012
+quay.io/pawsey/openfoam:v2006
+quay.io/pawsey/openfoam:v1912
 quay.io/pawsey/openfoam-org:10
 quay.io/pawsey/openfoam-org:9
 quay.io/pawsey/openfoam-org:8


### PR DESCRIPTION
This HASH of the shpc_registry_version was updated in order to catch the latest contributions of Pawsey into the main shpc-registry repo.

Also, the logic for renaming ${tool} directories to ${tool}-container was modified in order to avoid undesired nesting of directory names when the ${tool}-container directory already exists.