### PR TITLE
Add VTST variant for VASP

### DIFF
--- a/repo/packages/vasp/vtst-5:6.1.patch
+++ b/repo/packages/vasp/vtst-5:6.1.patch
@@ -1,0 +1,45 @@
+diff -r -c vasp.5.4.4/src/.objects vasp.5.4.4+vtst/src/.objects
+*** vasp.5.4.4/src/.objects	2017-04-20 17:04:05.000000000 +0800
+--- vasp.5.4.4+vtst/src/.objects	2023-04-14 23:33:39.000000000 +0800
+***************
+*** 69,74 ****
+--- 69,76 ----
+  	tet.o \
+  	tetweight.o \
+  	hamil_rot.o \
++ 	bfgs.o dynmat.o instanton.o lbfgs.o sd.o cg.o dimer.o bbm.o \
++ 	fire.o lanczos.o neb.o qm.o opt.o \
+  	chain.o \
+  	dyna.o \
+  	k-proj.o \
+***************
+*** 268,273 ****
+--- 270,277 ----
+  	tet.o \
+  	tetweight.o \
+  	hamil_rot.o \
++ 	bfgs.o dynmat.o instanton.o lbfgs.o sd.o cg.o dimer.o bbm.o \
++ 	fire.o lanczos.o neb.o qm.o opt.o \
+  	chain.o \
+  	dyna.o \
+  	k-proj.o \
+diff -r -c vasp.5.4.4/src/main.F vasp.5.4.4+vtst/src/main.F
+*** vasp.5.4.4/src/main.F	2017-04-20 17:03:58.000000000 +0800
+--- vasp.5.4.4+vtst/src/main.F	2023-04-14 23:29:17.000000000 +0800
+***************
+*** 3144,3150 ****
+        ENDIF
+  
+        CALL CHAIN_FORCE(T_INFO%NIONS,DYN%POSION,TOTEN,TIFOR, &
+!            LATT_CUR%A,LATT_CUR%B,IO%IU6)
+  
+        CALL PARALLEL_TEMPERING(NSTEP,T_INFO%NIONS,DYN%POSION,DYN%VEL,TOTEN,TIFOR,DYN%TEBEG,DYN%TEEND, &
+             LATT_CUR%A,LATT_CUR%B,IO%IU6)
+--- 3144,3150 ----
+        ENDIF
+  
+        CALL CHAIN_FORCE(T_INFO%NIONS,DYN%POSION,TOTEN,TIFOR, &
+!            TSIF, LATT_CUR%A,LATT_CUR%B,IO%IU6)
+  
+        CALL PARALLEL_TEMPERING(NSTEP,T_INFO%NIONS,DYN%POSION,DYN%VEL,TOTEN,TIFOR,DYN%TEBEG,DYN%TEEND, &
+             LATT_CUR%A,LATT_CUR%B,IO%IU6)

--- a/repo/packages/vasp/vtst-6.3:.patch
+++ b/repo/packages/vasp/vtst-6.3:.patch
@@ -1,0 +1,90 @@
+diff -r -c vasp.6.3.0/src/.objects vasp.6.3.0+vtst/src/.objects
+*** vasp.6.3.0/src/.objects	2022-01-20 23:10:06.000000000 +0800
+--- vasp.6.3.0+vtst/src/.objects	2023-04-14 23:52:21.000000000 +0800
+***************
+*** 115,120 ****
+--- 115,124 ----
+  	dos.o \
+  	elf.o \
+  	hamil_rot.o \
++ 	bfgs.o dynmat.o instanton.o lbfgs.o sd.o cg.o dimer.o bbm.o \
++ 	fire.o lanczos.o neb.o qm.o \
++ 	pyamff_fortran/*.o ml_pyamff.o \
++ 	opt.o \
+  	chain.o \
+  	dyna.o \
+  	fileio.o \
+diff -r -c vasp.6.3.0/src/main.F vasp.6.3.0+vtst/src/main.F
+*** vasp.6.3.0/src/main.F	2022-01-20 23:10:07.000000000 +0800
+--- vasp.6.3.0+vtst/src/main.F	2023-04-14 23:50:28.000000000 +0800
+***************
+*** 922,928 ****
+  ! init all chains (INCAR reader)
+  !-----------------------------------------------------------------------
+        LCHAIN = IMAGES > 0 .AND. .NOT.AFQMC_SET % ACTIVE
+!       IF (LCHAIN) CALL chain_init( T_INFO, IO)
+  !-----------------------------------------------------------------------
+  !xml finish copying parameters from INCAR to xml file
+  ! no INCAR reading from here 
+--- 922,928 ----
+  ! init all chains (INCAR reader)
+  !-----------------------------------------------------------------------
+        LCHAIN = IMAGES > 0 .AND. .NOT.AFQMC_SET % ACTIVE
+!       CALL chain_init( T_INFO, IO)
+  !-----------------------------------------------------------------------
+  !xml finish copying parameters from INCAR to xml file
+  ! no INCAR reading from here 
+***************
+*** 3517,3523 ****
+        ENDIF
+  
+        CALL CHAIN_FORCE(T_INFO%NIONS,DYN%POSION,TOTEN,TIFOR, &
+!            LATT_CUR%A,LATT_CUR%B,IO%IU6)
+  
+        CALL PARALLEL_TEMPERING(NSTEP,T_INFO%NIONS,DYN%POSION,DYN%VEL,TOTEN,TIFOR,DYN%TEBEG,DYN%TEEND, &
+             LATT_CUR%A,LATT_CUR%B,IO%IU6)
+--- 3517,3523 ----
+        ENDIF
+  
+        CALL CHAIN_FORCE(T_INFO%NIONS,DYN%POSION,TOTEN,TIFOR, &
+!            TSIF, LATT_CUR%A,LATT_CUR%B,IO%IU6)
+  
+        CALL PARALLEL_TEMPERING(NSTEP,T_INFO%NIONS,DYN%POSION,DYN%VEL,TOTEN,TIFOR,DYN%TEBEG,DYN%TEEND, &
+             LATT_CUR%A,LATT_CUR%B,IO%IU6)
+diff -r -c vasp.6.3.0/src/makefile vasp.6.3.0+vtst/src/makefile
+*** vasp.6.3.0/src/makefile	2022-01-20 23:10:06.000000000 +0800
+--- vasp.6.3.0+vtst/src/makefile	2023-04-14 23:53:58.000000000 +0800
+***************
+*** 14,20 ****
+  OFLAG=$(OFLAG_2)
+  OFLAG_IN=$(OFLAG)
+  
+! LIB=lib parser
+  LLIB=-Llib -ldmy -Lparser -lparser
+  
+  SRCDIR=../../src
+--- 14,20 ----
+  OFLAG=$(OFLAG_2)
+  OFLAG_IN=$(OFLAG)
+  
+! LIB=lib parser pyamff_fortran
+  LLIB=-Llib -ldmy -Lparser -lparser
+  
+  SRCDIR=../../src
+***************
+*** 145,151 ****
+  	$(MAKE) -C $@ -j1
+  #	$(MAKE) -C $@
+  
+! dependencies: sources
+  	$(MAKE) depend
+  
+  depend: $(F90SRC)
+--- 145,151 ----
+  	$(MAKE) -C $@ -j1
+  #	$(MAKE) -C $@
+  
+! dependencies: sources libs
+  	$(MAKE) depend
+  
+  depend: $(F90SRC)


### PR DESCRIPTION
* Adds resource, patches to support VTST extenstions for VASP for versions 5.4.4, 6.1, 6.3.

Note that the VASP license does not permit us to install modified versions of VASP; the recipe additions are intended to make it simpler for users to install their own modified versions.