### PR TITLE
Removes AMD PyTorch and TensorFlow containers

### DIFF
--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -105,8 +105,6 @@ wrf
 
 container_list="
 amazon/aws-cli:2.13.0
-amdih/pytorch:rocm5.0_ubuntu18.04_py3.7_pytorch_1.10.0
-rocm/tensorflow:rocm5.5-tf2.11-dev
 quay.io/biocontainers/bamtools:2.5.2--hd03093a_0
 quay.io/biocontainers/bbmap:38.96--h5c4e2a8_0
 quay.io/biocontainers/bcftools:1.15--haf5b3da_0


### PR DESCRIPTION
Those containers do not work. We will need to install our own. Working on publishing them on Quay.io. I will add the required lines here when that happens.