### PR TITLE
Sets rust not buildable and comments it out of the environment.

### DIFF
--- a/systems/setonix/configs/site/packages.yaml
+++ b/systems/setonix/configs/site/packages.yaml
@@ -152,8 +152,6 @@ packages:
 #      prefix: /usr
   ruby:
     version: [3.1.0]
-  rust:
-    version: [1.70.0]
   # preferred versions and variants, num_libs
   amdblis:
     version: [3.0]
@@ -299,6 +297,11 @@ packages:
       prefix: /usr
     buildable: false
 
+  rust:
+    externals:
+    - spec: rust@1.78.0
+      prefix: /software/setonix/2024.05/software/linux-sles15-zen3/gcc-12.2.0/rust-1.78.0/toolchains/stable-x86_64-unknown-linux-gnu
+    buildable: false
 
 # ----------------------------------------------------------------------------
 #                                        CRAY

--- a/systems/setonix/environments/langs/spack.yaml
+++ b/systems/setonix/environments/langs/spack.yaml
@@ -17,7 +17,8 @@ spack:
     - ruby@3.1.0
     
     # latest version of rust available may have issues but spack listed latest release is fine. 
-    - rust@1.70.0 ^python@3.11.6 +optimizations+zlib
+    # CRISTIAN: commenting it out because the installation causes issues https://github.com/spack/spack/issues/44201
+    # - rust@1.70.0 ^python@3.11.6 +optimizations+zlib
   - py-utilities:
     - py-pip@23.1.2
     - py-setuptools@68.0.0


### PR DESCRIPTION
@ddeeptimahanti  I needed to comment out rust from the environment otherwise it would conflict with `buildable: false`