### PR TITLE
Preliminary Spack and Python install for Ella. 

### DIFF
--- a/ella_test_install.sh
+++ b/ella_test_install.sh
@@ -1,0 +1,30 @@
+# Test install script for the pawsey-spack-config ella-setup branch
+
+export DATE_TAG=2024.06
+export SYSTEM=ella
+
+# .pawsey_project is not sourced on ella
+if [ -z "${MYSOFTWARE}" ]; then
+	export MYSOFTWARE="/pawsey/software/projects/$PAWSEY_PROJECT/$USER"
+fi
+
+if [ -z "${PAWESY_PROJECT}" ]; then
+	export PAWSEY_PROJECT=pawsey0001
+fi
+
+if [ -z "${INSTALL_GROUP}" ]; then
+	export INSTALL_GROUP=$PAWSEY_PROJECT
+fi
+
+# Create directory for Spack install, see below.
+export ACTUAL_INSTALL_PREFIX="/pawsey/software/projects/${PAWSEY_PROJECT}/${USER}/spack-${DATE_TAG}"
+mkdir -p $ACTUAL_INSTALL_PREFIX
+
+# Installing in a deep directory caused a shebang error.
+# Using a symlink in the user home directory a workaround.
+export INSTALL_PREFIX="/home/${USER}/spack-${DATE_TAG}"
+if [ ! -L "${INSTALL_PREFIX}" ]; then
+	    ln -s "$ACTUAL_INSTALL_PREFIX" "$INSTALL_PREFIX"
+fi
+
+./scripts/install_spack.sh

--- a/ella_test_install.sh
+++ b/ella_test_install.sh
@@ -3,6 +3,8 @@
 export DATE_TAG=2024.06
 export SYSTEM=ella
 
+export PAWSEY_PROJECT=pawsey0001
+
 # .pawsey_project is not sourced on ella
 if [ -z "${MYSOFTWARE}" ]; then
 	export MYSOFTWARE="/pawsey/software/projects/$PAWSEY_PROJECT/$USER"
@@ -27,4 +29,5 @@ if [ ! -L "${INSTALL_PREFIX}" ]; then
 	    ln -s "$ACTUAL_INSTALL_PREFIX" "$INSTALL_PREFIX"
 fi
 
-./scripts/install_spack.sh
+. ./scripts/install_spack.sh
+. ./scripts/install_python.sh

--- a/scripts/install_python.sh
+++ b/scripts/install_python.sh
@@ -38,5 +38,7 @@ spack -d spec python@${python_version} %gcc@${gcc_version}
 echo "Installing Python with default compilers.."
 for arch in $archs; do
     sg $INSTALL_GROUP -c "spack install --no-checksum python@${python_version} %gcc@${gcc_version} target=$arch"
-    sg $INSTALL_GROUP -c "spack install --no-checksum python@${python_version} %cce@${cce_version} target=$arch"
+    if [ "$SYSTEM" != "ella" ]; then
+    	sg $INSTALL_GROUP -c "spack install --no-checksum python@${python_version} %cce@${cce_version} target=$arch"
+    fi
 done

--- a/scripts/install_spack.sh
+++ b/scripts/install_spack.sh
@@ -31,20 +31,20 @@ if ! [ -e ${INSTALL_PREFIX}/spack ]; then
   git checkout v${spack_version}
 
   # apply Marco's LMOD fixes into spack tree
-  patch ${INSTALL_PREFIX}/spack/lib/spack/spack/modules/lmod.py \
-    ${PAWSEY_SPACK_CONFIG_REPO}/fixes/lmod_arch_family.patch
-  # Pascal's enhancements to modulefiles
-  patch ${INSTALL_PREFIX}/spack/lib/spack/spack/modules/common.py \
-    ${PAWSEY_SPACK_CONFIG_REPO}/fixes/modulenames_plus_common.patch
-  patch ${INSTALL_PREFIX}/spack/lib/spack/spack/cmd/modules/__init__.py \
-    ${PAWSEY_SPACK_CONFIG_REPO}/fixes/modulenames_plus_init.patch
-  patch ${INSTALL_PREFIX}/spack/lib/spack/spack/paths.py \
-    ${PAWSEY_SPACK_CONFIG_REPO}/fixes/dot_spack.patch
-  sed -i -e "s|DATE_TAG|$DATE_TAG|g"\
-    -e "s|PAWSEY_SYSTEM|$SYSTEM|g"\
-    ${INSTALL_PREFIX}/spack/lib/spack/spack/paths.py
-  
-  rm "${INSTALL_PREFIX}/spack/.git" -rf
+  #patch ${INSTALL_PREFIX}/spack/lib/spack/spack/modules/lmod.py \
+  #  ${PAWSEY_SPACK_CONFIG_REPO}/fixes/lmod_arch_family.patch
+  ## Pascal's enhancements to modulefiles
+  #patch ${INSTALL_PREFIX}/spack/lib/spack/spack/modules/common.py \
+  #  ${PAWSEY_SPACK_CONFIG_REPO}/fixes/modulenames_plus_common.patch
+  #patch ${INSTALL_PREFIX}/spack/lib/spack/spack/cmd/modules/__init__.py \
+  #  ${PAWSEY_SPACK_CONFIG_REPO}/fixes/modulenames_plus_init.patch
+  #patch ${INSTALL_PREFIX}/spack/lib/spack/spack/paths.py \
+  #  ${PAWSEY_SPACK_CONFIG_REPO}/fixes/dot_spack.patch
+  #sed -i -e "s|DATE_TAG|$DATE_TAG|g"\
+  #  -e "s|PAWSEY_SYSTEM|$SYSTEM|g"\
+  #  ${INSTALL_PREFIX}/spack/lib/spack/spack/paths.py
+  #
+  #rm "${INSTALL_PREFIX}/spack/.git" -rf
   cd -
 fi
 

--- a/systems/ella/configs/site/compilers.yaml
+++ b/systems/ella/configs/site/compilers.yaml
@@ -37,10 +37,10 @@ compilers:
 - compiler:
     spec: gcc@12.3.0
     paths:
-      cc: gcc-12
-      cxx: g++-12
-      f77: gfortran-12
-      fc: gfortran-12
+      cc: /usr/bin/gcc-12
+      cxx: /usr/bin/g++-12
+      f77: /usr/bin/gfortran-12
+      fc: /usr/bin/gfortran-12
     flags:
       cflags: -O3
       cxxflags: -O3
@@ -48,17 +48,17 @@ compilers:
       fflags: -O3 -fallow-argument-mismatch
     operating_system: ubuntu
     target: any
-    modules: {}
+    modules:
     environment: {}
     extra_rpaths: []
 
 - compiler:
     spec: gcc@11.4.1
     paths:
-      cc: gcc
-      cxx: g++
-      f77: gfortran
-      fc: gfortran
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
     flags:
       cflags: -O3
       cxxflags: -O3
@@ -66,7 +66,7 @@ compilers:
       fflags: -O3 -fallow-argument-mismatch
     operating_system: rocky
     target: any
-    modules: {}
+    modules:
     environment: {}
     extra_rpaths: []
 

--- a/systems/ella/configs/site/packages.yaml
+++ b/systems/ella/configs/site/packages.yaml
@@ -52,7 +52,7 @@ packages:
   libseccomp:
     version: [2.5.3]
   zlib:
-    version: [1.10.4]
+    version: []
   zstd:
     version: [1.4.8]
   json-c:
@@ -76,7 +76,7 @@ packages:
     version: [3.11.6]
     variants: '+optimizations +zlib +sqlite3 +tkinter ~ssl'
   gdbm:
-    version: [1.23.1]
+    version: [1.23]
   apr:
     version: [1.7.4]
   gettext:

--- a/systems/ella/settings.sh
+++ b/systems/ella/settings.sh
@@ -28,13 +28,15 @@ if [ "$USER" = "spack" ]; then
     INSTALL_GROUP="spack"
 fi
 
+echo $INSALL_GROUP
+
 if [ -z ${INSTALL_GROUP+x} ]; then
     echo "The 'INSTALL_GROUP' variable must be set to linux group that will own the installed files."
     exit 1
 fi
 
 # Note the use of '' instead of "" to allow env variables to be present in config files
-USER_PERMANENT_FILES_PREFIX='/pawsey/ella/projects/'
+USER_PERMANENT_FILES_PREFIX="/pawsey/software/projects/pawsey0001/ella"
 USER_TEMP_FILES_PREFIX='/tmp'
 SPACK_USER_CONFIG_PATH="$MYSOFTWARE/ella/$DATE_TAG/.spack_user_config"
 BOOTSTRAP_PATH='$MYSOFTWARE/ella/'$DATE_TAG/.spack_user_config/bootstrap
@@ -47,12 +49,12 @@ SPACK_POPULATE_CACHE=0
 
 pawseyenv_version="${DATE_TAG}"
 
-archs="arm64"
+archs="armv9.0a"
 # compiler versions (needed for module trees with compiler dependency)
 gcc_version="12.3.0"
 
 # architecture of login/compute nodes (needed by Singularity symlink module)
-cpu_arch="arm64"
+cpu_arch="armv9.0a"
 
 # tool versions
 spack_version="0.21.0" # the prefix "v" is added in setup_spack.sh
@@ -180,9 +182,9 @@ singularity_name_general="singularityce"
 
 # NOTE: the following are ALL RELATIVE to root_dir above
 # root location for Pawsey custom builds
-custom_root_dir="custom"
+custom_root_dir="/pawsey/software/projects/pawsey0001"
 # root location for Pawsey utilities (spack, shpc, scripts)
-utilities_root_dir="/pawsey/software/projects/pawsey0001"
+utilities_root_dir="utilities"
 # root location for containers
 containers_root_dir="containers"
 # location for Pawsey custom build modules


### PR DESCRIPTION
Various minor changes to support deployment of Spack on Ella.

The script `ella_test_install.sh` sets the necessary environment variables and runs `./scripts/install_spack.sh` and `./scripts/install_python.sh`.

The `./systems/ella/settings.sh` script sets the `USER_PERMANENT_FILES_PREFIX` and `root_dir` environment variables to locations in `/pawsey/software/projects/pawsey0001`, as this is the highest-level directory on `/software` where I have write permissions. This is a temporary workaround.