### PR TITLE
Allows project-wide installations to be seen by user-private Spack runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ This is where system specific configurations are placed. In particular, the foll
 
 * `configs/` is a directory containing `yaml` configuraiton files for Spack. There are three types of configuration:
   * `site/`: Spack configuration files that are valid for all users, which will sit in `$spack/etc/spack`.
-  * `project/`: Spack configuration files that are valid for project-wide installations executed by any user using the dedicated script `spack_project.sh`.
-  * `spackuser/`: Spack configuration files for system-wide installs, performed by Pawsey staff, which will sit in `/home/spack/.spack/`, allowing the `spack` user to override system-wide settings.
+  * `project/`: Spack configuration files that are valid for project-wide installations executed by any user using the custom Spack command `spack project [...]`.
+  * `spackuser/`: Spack configuration files for system-wide installation, performed by Pawsey staff using the `spack` linux user,  allowing to override the `site` settings.
 * `environments/`: Spack environments to be deployed.
 * `templates/`: modulefile templates for Spack.
 

--- a/systems/setonix/configs/site/upstreams.yaml
+++ b/systems/setonix/configs/site/upstreams.yaml
@@ -1,12 +1,16 @@
 upstreams:
-# this is the location of the system wide installation
-# it acts as an upstream installation for user-specific installations
+  # Project-wide installations are made visible to use-private spack commands to provide
+  # dependencies. They are also listed before the system-wide upstream because 
+  # project-wide installations may depend on system-wide ones.
+  project_wide:
+    install_tree: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG/software
+
+  # this is the location of the system wide installation
+  # it acts as an upstream installation for project-wide and user-specific installations
   system_wide:
     install_tree: INSTALL_PREFIX/software
 
-  project_wide:
-    install_tree: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG/software
-# autoload+upstream currently does not work, 
+#  autoload+upstream currently does not work, 
 # so better not to expose upstreams modules to user installations
 #    modules:
 #      lmod: INSTALL_PREFIX/modules

--- a/systems/setonix/configs/site/upstreams.yaml
+++ b/systems/setonix/configs/site/upstreams.yaml
@@ -3,6 +3,9 @@ upstreams:
 # it acts as an upstream installation for user-specific installations
   system_wide:
     install_tree: INSTALL_PREFIX/software
+
+  project_wide:
+    install_tree: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG/software
 # autoload+upstream currently does not work, 
 # so better not to expose upstreams modules to user installations
 #    modules:


### PR DESCRIPTION
Previously, user-private Spack installations could not use project-wide installations as dependencies because they were not seen. In other words, the project-wide installation directory was not set as upstream.

Fixes #278