### PR TITLE
Adds MWA packages to the system-wide installation

### DIFF
--- a/systems/setonix/configs/spackuser/modules.yaml
+++ b/systems/setonix/configs/spackuser/modules.yaml
@@ -352,7 +352,15 @@ modules:
         "wsclean ~mpi ~idg ~everybeam": 'astro-applications/{name}/{version}'
         "wsclean ~mpi +idg ~everybeam": 'astro-applications/{name}/{version}-idg'
         "wsclean ~mpi +idg +everybeam": 'astro-applications/{name}/{version}-idg-everybeam'
-
+        mwalib: 'astro-applications/{name}/{version}'
+        birli: 'astro-applications/{name}/{version}'
+        presto: 'astro-applications/{name}/{version}'
+        calceph: 'astro-applications/{name}/{version}'
+        giant-squid: 'astro-applications/{name}/{version}'
+        'hyperbeam +rocm': 'astro-applications/{name}-amd-gfx90a/{version}'
+        hyperbeam: 'astro-applications/{name}/{version}'
+        'hyperdrive +rocm': 'astro-applications/{name}-amd-gfx90a/{version}'
+        hyperdrive: 'astro-applications/{name}/{version}'
         #performance tests 
         "hpl ~openmp": 'benchmarking/{name}/{version}'
         "hpl +openmp": 'benchmarking/{name}/{version}+openmp'

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -56,6 +56,7 @@ spack:
     - birli@0.15.1 ~portable
     - calceph@3.5.5 target=zen3
     - presto@5.0.1 target=zen3
+    - casacore@3.5.0 datapath=setonix build_type=Release target=zen3
 
   - mwa-no-python:
     - chgcentre build_type=Release target=zen3

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -48,7 +48,6 @@ spack:
     - mwalib@1.5.0+python~portable
     - giant-squid@1.0.3
     - aoflagger@3.4.0
-    - wsclean@3.4+everybeam+idg
     - hyperbeam@0.9.3 ~portable +python
     - hyperbeam@0.9.3 ~portable +rocm +python amdgpu_target=gfx90a
     - hyperdrive@0.4.1 ~portable

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -40,21 +40,25 @@ spack:
     - xerces-c transcoder=gnuiconv
     - xerces-c transcoder=iconv  
     - subversion
-  - mwa-util-set:
-    - chgcentre
-    - wsclean@3.4 +mpi +idg +everybeam
-    - wsclean@3.4 ~mpi +idg +everybeam
-    - wsclean@2.9 +idg
+
+  - mwa-with-python:
+    - wsclean@3.4 +mpi +idg +everybeam build_type=Release target=zen3
+    - wsclean@3.4 ~mpi +idg +everybeam build_type=Release target=zen3
+    - wsclean@2.9 +idg build_type=Release target=zen3
     - mwalib@1.5.0+python~portable
-    - giant-squid@1.0.3
-    - aoflagger@3.4.0
+    - giant-squid@1.0.3 target=zen3
+    - giant-squid@1.0.3 target=zen2
+    - aoflagger@3.4.0 build_type=Release target=zen3 ^cfitsio@3.49
     - hyperbeam@0.9.3 ~portable +python
     - hyperbeam@0.9.3 ~portable +rocm +python amdgpu_target=gfx90a
     - hyperdrive@0.4.1 ~portable
     - hyperdrive@0.4.1 ~portable amdgpu_target=gfx90a +rocm
     - birli@0.15.1 ~portable
-    - calceph@3.5.5
-    - presto@5.0.1
+    - calceph@3.5.5 target=zen3
+    - presto@5.0.1 target=zen3
+
+  - mwa-no-python:
+    - chgcentre build_type=Release target=zen3
 
   # TODO add versions 
   - python-astro-set:
@@ -82,13 +86,16 @@ spack:
     - [$astro-util-set, $askap-util-set]
     - ['%gcc@12.2.0']
     - [target=zen3]
+
   - matrix:
-    - [$mwa-util-set]
-    - [^python@3.11.6]
-    - [^cfitsio@3.49]
+    - [ $mwa-no-python]
     - ['%gcc@12.2.0']
-    - ['build_type=Release']
-    - [target=zen3]
+
+  - matrix:
+    - [$mwa-with-python]
+    - [^python@3.11.6]
+    - ['%gcc@12.2.0']
+
   - matrix:
     - [$python-astro-set]
     - [^python@3.11.6]

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -41,14 +41,22 @@ spack:
     - xerces-c transcoder=iconv  
     - subversion
   - mwa-util-set:
-    - chgcentre build_type=Release ^casacore ~python build_type=Release
-    #  - mwa-util-set-with-python:
-    #    - wsclean@3.0 +mpi +idg +everybeam build_type=Release ^chgcentre build_type=Release
-    #  ^casacore ~python build_type=Release
-    #- wsclean@3.0 ~mpi +idg +everybeam build_type=Release ^chgcentre build_type=Release
-    #  ^casacore ~python build_type=Release
-    #- wsclean@2.10.1 build_type=Release ^chgcentre build_type=Release ^casacore ~python
-    #  build_type=Release
+    - chgcentre
+    - wsclean@3.4 +mpi +idg +everybeam
+    - wsclean@3.4 ~mpi +idg +everybeam
+    - wsclean@2.9 +idg
+    - mwalib@1.5.0+python~portable
+    - giant-squid@1.0.3
+    - aoflagger@3.4.0
+    - wsclean@3.4+everybeam+idg
+    - hyperbeam@0.9.3 ~portable +python
+    - hyperbeam@0.9.3 ~portable +rocm +python amdgpu_target=gfx90a
+    - hyperdrive@0.4.1 ~portable
+    - hyperdrive@0.4.1 ~portable amdgpu_target=gfx90a +rocm
+    - birli@0.15.1 ~portable
+    - calceph@3.5.5
+    - presto@5.0.1
+
   # TODO add versions 
   - python-astro-set:
     - py-funcsigs #package not available in spack/0.20.0, using recipe from 0.19.0
@@ -75,14 +83,12 @@ spack:
     - [$astro-util-set, $askap-util-set]
     - ['%gcc@12.2.0']
     - [target=zen3]
-      #- matrix:
-      #  - [$mwa-util-set-with-python]
-      #  - [^python@3.11.6]
-      #  - ['%gcc@12.2.0']
-      #  - [target=zen3]
   - matrix:
     - [$mwa-util-set]
+    - [^python@3.11.6]
+    - [^cfitsio@3.49]
     - ['%gcc@12.2.0']
+    - ['build_type=Release']
     - [target=zen3]
   - matrix:
     - [$python-astro-set]


### PR DESCRIPTION
In previous PRs, recipes for MWA radio astronomy applications were added to our repository.

This PR modifies the deployment process such that these packages are also installed system-wide at every deployment.

For the next maintenance, the packages will be installed "manually" by implementing these same changes locally to the `spack` user. In that sense, we can use this PR to also double check the changes that will be implemented in the next maintenance.

Paging @d3v-null for awareness. 