### PR TITLE
Enables CFITSIO's reentrant option.

### DIFF
--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -22,7 +22,8 @@ spack:
   - casacore-new-set:
     - casacore@3.5.0 +openmp+python+hdf5 build_type=Release
   - astro-util-set:
-    - cfitsio
+    - cfitsio@3.49 +reentrant
+    - cfitsio@4.4.0 +reentrant
     - wcslib +cfitsio
     - wcslib ~cfitsio  
     - pgplot


### PR DESCRIPTION
The reentrant option allows the use of the library in multithreaded environments https://heasarc.gsfc.nasa.gov/fitsio/c/c_user/node15.html 
Also, adds older 3.49 version for compatibility reasons. Seems like version 4.x breaks some MWA software.

Paging @d3v-null for awareness