### PR TITLE
Enables project-wide installations with SHPC

### DIFF
--- a/scripts/install_shpc.sh
+++ b/scripts/install_shpc.sh
@@ -88,6 +88,7 @@ shpc config set "default_view:${shpc_containers_modules_dir##*/}"
 shpc config set "singularity_module:${singularity_name}/${singularity_version}"
 # enable wrapper scripts
 shpc config set wrapper_scripts:enabled:true
+shpc config set "wrapper_base:${USER_PERMANENT_FILES_PREFIX}/\$PAWSEY_PROJECT/\$USER/setonix/$DATE_TAG/containers/wrappers"
 # GPU support (Phase 2)
 #shpc config set container_features:gpu:amd
 # enable X11 graphics

--- a/scripts/install_shpc.sh
+++ b/scripts/install_shpc.sh
@@ -40,6 +40,16 @@ fi
 # pip install package
 sg ${INSTALL_GROUP} -c "pip install --prefix=${INSTALL_PREFIX}/${shpc_install_dir} singularity-hpc==${shpc_version}"
 
+# install here custom shpc wrapper
+cd ${INSTALL_PREFIX}/${shpc_install_dir}/bin
+[ -e realshpc ] || mv shpc realshpc
+sed -e "s;REALSHPC;${INSTALL_PREFIX}/${shpc_install_dir}/bin/realshpc;g" \
+  -e "s|DATE_TAG|$DATE_TAG|g"\
+  -e "s|USER_PERMANENT_FILES_PREFIX|${USER_PERMANENT_FILES_PREFIX}|g"\
+   ${PAWSEY_SPACK_CONFIG_REPO}/scripts/templates/shpc > shpc 
+chmod a+rx shpc
+cd -
+
 # get registry from github repo
 if ! [ -e "${INSTALL_PREFIX}/${shpc_install_dir}/registry" ]; then
     # get registry from github repo

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -68,7 +68,9 @@ prepend_path("LMOD_CUSTOM_COMPILER_AOCC_3_0_PREFIX", psc_sw_env_user_modules_roo
 -- Add User SHPC modules to MODULEPATH
 local psc_sw_env_shpc_user_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/" .. psc_sw_env_user .. "/setonix/DATE_TAG/" .. psc_sw_env_shpc_containers_modules_dir
 prepend_path("MODULEPATH", psc_sw_env_shpc_user_root)
-
+ -- and the project-wide SHPC modules..
+local psc_sw_env_shpc_project_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/setonix/DATE_TAG/" .. psc_sw_env_shpc_containers_modules_dir
+prepend_path("MODULEPATH", psc_sw_env_shpc_project_root)
 
 -- Add Project modules to Cray Lmod hierarchy variables
 local psc_sw_env_project_modules_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/setonix/DATE_TAG/modules/" .. arch

--- a/scripts/templates/shpc
+++ b/scripts/templates/shpc
@@ -8,21 +8,14 @@ if (( $# > 0 )) && [ "$1" = "project" ]; then
     umask g+rwx
 
     BASE_PATH=USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG
-    
-    MODULES_FULLPATH=${BASE_PATH}/modules/${MODULE_SUBPATH}/${COMPILER_VERSION}
 
     SHPC_OPTIONS="-c set:wrapper_base:${BASE_PATH}/containers/wrappers
          -c set:container_base:${BASE_PATH}/containers/sifs
          -c set:module_base:${BASE_PATH}/containers/modules-long
          -c set:views_base:${BASE_PATH}/containers/views/modules
-         -c set:default_view:" 
+         -c set:default_view:modules"
     
     ${REALSHPC} ${SHPC_OPTIONS} ${@}
-    # This was a workaround to have modules visible in current configuration
-    # copy module file
-    [ -e "${MODULES_FULLPATH}/${CONTAINER_NAME}" ] || mkdir -p "${MODULES_FULLPATH}/${CONTAINER_NAME}"
-    cp -r "${BASE_PATH}/containers/modules-long/shpc_registry/${CONTAINER_NAME}/${CONTAINER_TAG}/module.lua" "${MODULES_FULLPATH}/${CONTAINER_NAME}/${CONTAINER_TAG}.lua"
-    echo "Modulefile installed."
 else
     ${REALSHPC} ${@}
 fi

--- a/scripts/templates/shpc
+++ b/scripts/templates/shpc
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+module load shpc/0.1.28 
+REALSHPC=`which shpc`
+
+if (( $# > 0 )) && [ "$1" = "project" ]; then
+    # enable group access and writing to the stack
+    umask g+rwx
+
+    BASE_PATH=USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG
+    
+    MODULES_FULLPATH=${BASE_PATH}/modules/${MODULE_SUBPATH}/${COMPILER_VERSION}
+
+    SHPC_OPTIONS="-c set:wrapper_base:${BASE_PATH}/containers/wrappers
+         -c set:container_base:${BASE_PATH}/containers/sifs
+         -c set:module_base:${BASE_PATH}/containers/modules-long
+         -c set:views_base:${BASE_PATH}/containers/views/modules
+         -c set:default_view:" 
+    
+    ${REALSHPC} ${SHPC_OPTIONS} ${@}
+    # This was a workaround to have modules visible in current configuration
+    # copy module file
+    [ -e "${MODULES_FULLPATH}/${CONTAINER_NAME}" ] || mkdir -p "${MODULES_FULLPATH}/${CONTAINER_NAME}"
+    cp -r "${BASE_PATH}/containers/modules-long/shpc_registry/${CONTAINER_NAME}/${CONTAINER_TAG}/module.lua" "${MODULES_FULLPATH}/${CONTAINER_NAME}/${CONTAINER_TAG}.lua"
+    echo "Modulefile installed."
+else
+    ${REALSHPC} ${@}
+fi

--- a/scripts/templates/shpc
+++ b/scripts/templates/shpc
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-module load shpc/0.1.28 
-REALSHPC=`which shpc`
-
 if (( $# > 0 )) && [ "$1" = "project" ]; then
     # enable group access and writing to the stack
     umask g+rwx
@@ -12,10 +9,10 @@ if (( $# > 0 )) && [ "$1" = "project" ]; then
     SHPC_OPTIONS="-c set:wrapper_base:${BASE_PATH}/containers/wrappers
          -c set:container_base:${BASE_PATH}/containers/sifs
          -c set:module_base:${BASE_PATH}/containers/modules-long
-         -c set:views_base:${BASE_PATH}/containers/views/modules
+         -c set:views_base:${BASE_PATH}/containers/views
          -c set:default_view:modules"
-    
-    ${REALSHPC} ${SHPC_OPTIONS} ${@}
+
+    REALSHPC ${SHPC_OPTIONS} ${@:2}
 else
-    ${REALSHPC} ${@}
+    REALSHPC ${@}
 fi

--- a/scripts/templates/spack_create_user_moduletree.sh
+++ b/scripts/templates/spack_create_user_moduletree.sh
@@ -28,9 +28,18 @@ done
 chmod --silent g+rwX "${project_root_dir}"
 chmod --silent -R g+rwX "${project_root_dir}/modules"
 
-# create shpc container modules base dir (symlinks - views)
+# create shpc user-private container modules base dir (symlinks - views)
 mkdir -p "${user_root_dir}/${shpc_containers_modules_dir}"
 cat << EOF >"${user_root_dir}/${shpc_containers_modules_dir}/view.yaml"
+view:
+  name: modules
+  modules: []
+  system_modules: []
+EOF
+
+# create project-wide shpc container modules base dir (symlinks - views)
+mkdir -p "${project_root_dir}/${shpc_containers_modules_dir}"
+cat << EOF >"${project_root_dir}/${shpc_containers_modules_dir}/view.yaml"
 view:
   name: modules
   modules: []

--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -209,7 +209,7 @@ shpc_containers_modules_dir="${containers_root_dir}/${shpc_allusers_modules_dir_
 # location for SHPC container modules (long version, as installed)
 shpc_containers_modules_dir_long="${containers_root_dir}/${shpc_allusers_modules_dir_long}"
 # location for SHPC containers
-shpc_containers_dir="${containers_root_dir}/sif"
+shpc_containers_dir="${containers_root_dir}/sifs"
 
 # suffix for Pawsey custom build modules
 custom_modules_suffix="custom"


### PR DESCRIPTION
This PR implements project-wide installations of container modules just like the `spack project` command allows Spack installations to be installed at the project level. Analogously, I implement a `shpc` wrapper script to execute SHPC with a custom configuration when the `project` keyword is passed as a first argument to the script.

