### PR TITLE
update birli, mwalib, wsclean

### DIFF
--- a/repo/packages/birli/package.py
+++ b/repo/packages/birli/package.py
@@ -21,6 +21,7 @@ class Birli(Package):
     variant("portable", default=True, description="Disable native CPU optimizations")
 
     depends_on("rust@1.64.0:", type="build")
+    depends_on("rust@1.65.0:", type="build", when="@0.16.0:")
     depends_on("cmake", type="build")
 
     # cfitsio > 4 introduces a breaking change, is incompatible with mwalib.

--- a/repo/packages/birli/package.py
+++ b/repo/packages/birli/package.py
@@ -9,6 +9,7 @@ class Birli(Package):
     maintainers = ["d3v-null"]
 
     version("main", branch="main")
+    version("0.16.0", tag="v0.16.0")
     version("0.15.1", tag="v0.15.1")
     version("0.14.0", tag="v0.14.0")
     version("0.13.0", tag="v0.13.0")

--- a/repo/packages/hyperbeam/package.py
+++ b/repo/packages/hyperbeam/package.py
@@ -21,6 +21,7 @@ class Hyperbeam(Package, ROCmPackage, CudaPackage):
     maintainers = ["d3v-null"]
 
     version("main", branch="main")
+    version("0.10.0", tag="v0.10.0")
     version("0.9.3", tag="v0.9.3")
     version("0.8.0", tag="v0.8.0")
     version("0.7.2", tag="v0.7.2")
@@ -32,6 +33,7 @@ class Hyperbeam(Package, ROCmPackage, CudaPackage):
     variant("portable", default=True, description="Disable native CPU optimizations")
 
     depends_on("rust@1.64.0:", type="build")
+    depends_on("rust@1.80.0:", type="build", when="@0.10.0:")
     depends_on("cmake", type="build")
 
     # cfitsio > 4 introduces a breaking change, is incompatible with mwalib.

--- a/repo/packages/hyperdrive/package.py
+++ b/repo/packages/hyperdrive/package.py
@@ -10,6 +10,8 @@ class Hyperdrive(Package, ROCmPackage, CudaPackage):
 
     version("main",  branch="main")
     version("0.4.1", tag="v0.4.1")
+    version("0.4.1-peel", tag="v0.4.1-peel")
+    version("0.4.1-devel", tag="v0.4.1-devel")
 
     # unknown issue on setonix when enabled https://github.com/PawseySC/pawsey-spack-config/pull/280#issuecomment-2296128762
     variant("cfitsio-static", default=False, description="Enable the fitsio_src feature of the fitsio-sys crate.")

--- a/repo/packages/mwalib/package.py
+++ b/repo/packages/mwalib/package.py
@@ -33,6 +33,7 @@ class Mwalib(Package):
     variant("portable", default=True, description="Disable native CPU optimizations")
 
     depends_on("rust@1.64.0:", type="build")
+    depends_on("rust@1.65.0:", type="build", when="@1.8:")
 
     # cfitsio > 4 introduces a breaking change, is incompatible with mwalib.
     # default spack cfitsio does not give the +reentrant option

--- a/repo/packages/mwalib/package.py
+++ b/repo/packages/mwalib/package.py
@@ -21,6 +21,7 @@ class Mwalib(Package):
     maintainers = ["d3v-null"]
 
     version("main", branch="main")
+    version("1.8.2", tag="v1.8.2")
     version("1.5.0", tag="v1.5.0")
     version("1.4.0", tag="v1.4.0")
     version("1.3.3", tag="v1.3.3")

--- a/repo/packages/wsclean/mpiv3.5.patch
+++ b/repo/packages/wsclean/mpiv3.5.patch
@@ -1,0 +1,24 @@
+diff --git a/distributed/mpibig.cpp b/distributed/mpibig.cpp
+index 2b69035..dbf8a93 100644
+--- a/distributed/mpibig.cpp
++++ b/distributed/mpibig.cpp
+@@ -4,6 +4,7 @@
+ 
+ #include <algorithm>
+ #include <cstdint>
++#include <cstddef>
+ 
+ using aocommon::Logger;
+ 
+diff --git a/distributed/mpibig.h b/distributed/mpibig.h
+index 47d0bbc..c6f2270 100644
+--- a/distributed/mpibig.h
++++ b/distributed/mpibig.h
+@@ -2,6 +2,7 @@
+ #define DISTRIBUTED_MPI_BIG_H_
+ 
+ #include <mpi.h>
++#include <cstddef>
+ 
+ namespace wsclean {
+ 

--- a/repo/packages/wsclean/package.py
+++ b/repo/packages/wsclean/package.py
@@ -51,8 +51,9 @@ class Wsclean(CMakePackage):
     depends_on('doxygen', when='@3.0:')
     depends_on('python', when='@3.0:')
     patch("wsclean_2.10.1.patch", when="@2.10.1")
-    patch('mpi1.patch', when='@3.0:')
-    patch('mpi2.patch', when='@3.0:')
+    patch('mpi1.patch', when='@3.0:3.4')
+    patch('mpi2.patch', when='@3.0:3.4')
+    patch('mpiv3.5.patch', when='@3.5:')
 
     @run_before("cmake")
     def change_source_dir(self):

--- a/repo/packages/wsclean/package.py
+++ b/repo/packages/wsclean/package.py
@@ -19,6 +19,7 @@ class Wsclean(CMakePackage):
 
     maintainers = ['dipietrantonio']
 
+    version('3.5', git='https://gitlab.com/aroffringa/wsclean.git', tag='v3.5', submodules=True)
     version('3.4', git='https://gitlab.com/aroffringa/wsclean.git', tag='v3.4', submodules=True)
     version('3.3', git='https://gitlab.com/aroffringa/wsclean.git', tag='v3.3', submodules=True)
     version('3.2', git='https://gitlab.com/aroffringa/wsclean.git', tag='v3.2', submodules=True)
@@ -44,6 +45,7 @@ class Wsclean(CMakePackage):
     depends_on('everybeam@0.4.0', when='@3.2 +everybeam')
     depends_on('everybeam@0.4.0', when='@3.3 +everybeam')
     depends_on('everybeam@0.5.2:0.5.8', when='@3.4 +everybeam')
+    depends_on('everybeam@0.6.0', when='@3.5 +everybeam')
     depends_on('mpi', when='+mpi')
     depends_on('blas', when='@3.0:')
     depends_on('doxygen', when='@3.0:')


### PR DESCRIPTION
I've tested a pre-release version of this Birli on setonix already, but my spack environment is trashed again so I can't test this particular tag.

by the way, I've ticked "allow edits by maintainers".

A newer hyperbeam is ready too, but it (and the next hyperdrive) will need rust 1.80 https://pawsey.atlassian.net/servicedesk/customer/portal/3/GS-30920