### PR TITLE
Update SHPC registry and PyTorch

### DIFF
--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -67,7 +67,7 @@ spack_version="0.23.0" # the prefix "v" is added in setup_spack.sh
 singularity_version="4.1.0-nompi" # has to match the version in the Spack env yaml + nompi tag
 singularity_mpi_version="4.1.0-mpi" # has to match the version in the Spack env yaml + mpi tag
 shpc_version="0.1.30"
-shpc_registry_version="6daa16631460b9a93db2b9580dae360397d00aa7"
+shpc_registry_version="9748412c407a1feed71837a79ad350a307e66253"
 
 # python (and py tools) versions
 python_name="python"
@@ -162,7 +162,7 @@ quay.io/pawsey/openfoam-org:10
 quay.io/pawsey/openfoam-org:9
 quay.io/pawsey/openfoam-org:8
 quay.io/pawsey/openfoam-org:7
-quay.io/pawsey/pytorch:2.2.0-rocm5.6.0
+quay.io/pawsey/pytorch:2.6.0-rocm6.2.2
 quay.io/pawsey/tensorflow:2.12.1.570-rocm5.6.0
 amdih/cp2k
 amdih/namd


### PR DESCRIPTION
Updates the SHPC registry version so to have the newest Pawsey PyTorch container uploaded at https://quay.io/repository/pawsey/pytorch?tab=tags