### PR TITLE
Changes naming convention for Dev Null's packages

### DIFF
--- a/systems/setonix/configs/spackuser/modules.yaml
+++ b/systems/setonix/configs/spackuser/modules.yaml
@@ -358,10 +358,12 @@ modules:
         presto: 'astro-applications/{name}/{version}'
         calceph: 'astro-applications/{name}/{version}'
         giant-squid: 'astro-applications/{name}/{version}'
-        'hyperbeam +rocm': 'astro-applications/{name}-amd-gfx90a/{version}'
-        hyperbeam: 'astro-applications/{name}/{version}'
-        'hyperdrive +rocm': 'astro-applications/{name}-amd-gfx90a/{version}'
-        hyperdrive: 'astro-applications/{name}/{version}'
+        # naming convention for astronomy GPU software does not follow
+        # the usual one as per explicit request of Dev Null.
+        'hyperbeam +rocm': 'astro-applications/{name}/{version}'
+        hyperbeam: 'astro-applications/{name}/{version}-cpu'
+        'hyperdrive +rocm': 'astro-applications/{name}/{version}'
+        hyperdrive: 'astro-applications/{name}/{version}-cpu'
         #performance tests 
         "hpl ~openmp": 'benchmarking/{name}/{version}'
         "hpl +openmp": 'benchmarking/{name}/{version}+openmp'


### PR DESCRIPTION
Dev Null requested that the GPU version of hyperbeam and hyperdrive to be named without the usual `amd-gfx90a` suffix, and to add a `cpu` suffix to the CPU versions instead.

@d3v-null please confirm these are the changes you wish for these packages, to keep a record of it.