### PR TITLE
Updated giant-squid to 2.12 and removed older incompatible versions

### DIFF
--- a/repo/packages/giant-squid/package.py
+++ b/repo/packages/giant-squid/package.py
@@ -15,13 +15,10 @@ class GiantSquid(Package):
 
     maintainers = ["gsleap", "d3v-null"]
 
+    version("2.1.1", tag="v2.1.1")
     version("2.1.0", tag="v2.1.0")
-    version("2.0.1", tag="v2.0.1")
-    version("1.1.0", tag="v1.1.0")
-    version("1.0.3", tag="v1.0.3")
 
     depends_on("rust@1.71.1:", when="@1.1.0:", type="build")
-    depends_on("rust@1.70.0:", when="@:1.0.3", type="build")
 
     def setup_build_environment(self, env):
         build_dir = self.stage.source_path

--- a/repo/packages/giant-squid/package.py
+++ b/repo/packages/giant-squid/package.py
@@ -15,6 +15,7 @@ class GiantSquid(Package):
 
     maintainers = ["gsleap", "d3v-null"]
 
+    version("2.1.2", tag="v2.1.2")
     version("2.1.1", tag="v2.1.1")
     version("2.1.0", tag="v2.1.0")
 

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -59,8 +59,8 @@ spack:
 
   - mwa-no-python:
     - chgcentre build_type=Release target=zen3
-    - giant-squid@2.1.1 target=zen3
-    - giant-squid@2.1.1 target=zen2
+    - giant-squid@2.1.2 target=zen3
+    - giant-squid@2.1.2 target=zen2
 
   # TODO add versions 
   - python-astro-set:

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -59,8 +59,8 @@ spack:
 
   - mwa-no-python:
     - chgcentre build_type=Release target=zen3
-    - giant-squid@2.1.0 target=zen3
-    - giant-squid@2.1.0 target=zen2
+    - giant-squid@2.1.1 target=zen3
+    - giant-squid@2.1.1 target=zen2
 
   # TODO add versions 
   - python-astro-set:


### PR DESCRIPTION
Apologies, but I realised we had a significant bug in giant-squid and I had not updated our PR with the new version. I have also removed older, incompatible giant-squid versions as they no longer work due to outdated API calls.

Update- 26-May-2025- had to release another quick hotfix (v2.1.2) of giant-squid to fix a bug