### PR TITLE
Changes to singularity module files for COS 25.3

### DIFF
--- a/systems/setonix/templates/modules/modulefile.lua
+++ b/systems/setonix/templates/modules/modulefile.lua
@@ -98,6 +98,8 @@ setenv("NXF_SINGULARITY_CACHEDIR", os.getenv("MYSOFTWARE").."/.nextflow_singular
 -- Singularity configuration START
 -- LD_LIBRARY_PATH addition 
 local singularity_ld_path = ""
+-- COS 25.3
+singularity_ld_path = singularity_ld_path .. ":/host_lib64"
 -- add CRAY_PATHS START
 singularity_ld_path = singularity_ld_path .. ":/opt/cray/pe/mpich/8.1.32/ofi/gnu/12.3/lib-abi-mpich:/opt/cray/pe/mpich/8.1.32/gtl/lib:/opt/cray/xpmem/default/lib64:/opt/cray/pe/pmi/default/lib:/opt/cray/pe/pals/default/lib"
 --singularity_ld_path = singularity_ld_path .. ":/opt/cray/pe/gcc-libs"
@@ -137,6 +139,8 @@ singularity_bindpath = singularity_bindpath .. ",/usr/lib64/libzstd.so.1"
 singularity_bindpath = singularity_bindpath .. ",/usr/lib64/libselinux.so.1"
 -- lustre 
 singularity_bindpath = singularity_bindpath .. ",/usr/lib64/liblustreapi.so.1,/usr/lib64/liblnetconfig.so.4,/usr/lib64/libyaml-0.so.2,/usr/lib64/libnl-genl-3.so.200,/usr/lib64/libnl-3.so.200"
+-- COS 25.3
+singularity_bindpath = singularity_bindpath .. ",/usr/lib64:/host_lib64"
 -- this has to be conditional, path exists only in compute nodes
 if isDir("/var/spool/slurmd") then
   singularity_bindpath = singularity_bindpath .. ",/var/spool/slurmd"


### PR DESCRIPTION
This updates the generated singularity module files to work with COS 25.3. Summary of changes:

- Change of paths for xpmem and some libraries
- Commenting out `/opt/cray/pe/gcc-libs/libstdc++.so.6` path, which conflicts with glibc in rebuilt containers
- Change mpich versions from 8.1.30 to 8.1.32
- Add a fix to enable MPI I/O to work in containers

Note that these changes are under the assumption of using rebuilt containers with newer ubuntu base image. Our existing containers using older ubuntu images are incompatible with these changes. Specifically, they need `/opt/cray/pe/gcc-libs/libstdc++.so.6` to be injected into the container, while the rebuilt containers cannot have it injected. The below sequence of commands can be run to have some of the existing containers work
```
export SINGULARITYENV_LD_LIBRARY_PATH=:/opt/cray/pe/gcc-libs:$SINGULARITYENV_LD_LIBRARY_PATH
export SINGULARITY_BINDPATH=,/lib64/libc.so.6,/lib64/ld-linux-x86-64.so.2,/lib64/libpthread.so.0,/lib64/librt.so.1,$SINGULARITY_BINDPATH
export SINGULARITYENV_LD_PRELOAD=:/lib64/libc.so.6:/lib64/ld-linux-x86-64.so.2:/lib64/libpthread.so.0:/lib64/librt.so.1:$SINGULARITYENV_LD_PRELOAD
```
although some containers and workflows still do not work with the host glibc change even with this workaround.