### PR TITLE
Removes the concretizer selection.

### DIFF
--- a/systems/setonix/configs/site/config.yaml
+++ b/systems/setonix/configs/site/config.yaml
@@ -52,7 +52,3 @@ config:
   # Cache directory for miscellaneous files, like the package index.
   # This can be purged with `spack clean --misc-cache`
   misc_cache: USER_TEMP_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/software/$USER/misc_cache
-
-  # concretizer: `clingo` or `original` (good for debugging concretisations)
-  concretizer: clingo
-  #concretizer: original

--- a/systems/setonix/configs/spackuser/config.yaml
+++ b/systems/setonix/configs/spackuser/config.yaml
@@ -46,7 +46,3 @@ config:
   # Cache directory for miscellaneous files, like the package index.
   # This can be purged with `spack clean --misc-cache`
   misc_cache: INSTALL_PREFIX/software/misc_cache
-
-  # concretizer: `clingo` or `original` (good for debugging concretisations)
-  concretizer: clingo
-  #concretizer: original


### PR DESCRIPTION
It is ignored starting from spack 0.23. See #313