### PR TITLE
Set helper environment variable in pawseyenv.lua

### DIFF
--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -108,3 +108,6 @@ local psc_sw_env_custom_modules_root = psc_sw_env_root_dir .. "/" .. psc_sw_env_
 prepend_path("LMOD_CUSTOM_COMPILER_GNU_12_0_PREFIX", psc_sw_env_custom_modules_root .. "/gcc/" .. psc_sw_env_gcc_version .. "/" .. psc_sw_env_custom_modules_suffix)
 prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_17_0_PREFIX", psc_sw_env_custom_modules_root .. "/cce/" .. psc_sw_env_cce_version .. "/" .. psc_sw_env_custom_modules_suffix)
 prepend_path("LMOD_CUSTOM_COMPILER_AOCC_4_1_PREFIX", psc_sw_env_custom_modules_root .. "/aocc/" .. psc_sw_env_aocc_version .. "/" .. psc_sw_env_custom_modules_suffix)
+
+-- Let scripts know which version of the software stack is loaded
+setenv("PAWSEY_STACK_VERSION", "DATE_TAG")


### PR DESCRIPTION
Setting the `PAWSEY_STACK_VERSION` variable helps user scripts to detect which version of the stack they are currently using.