### PR TITLE
Remove lmod messages in singularity shells

### DIFF
--- a/scripts/create_custom_singularity_modules_from_general_singularity_container_engine.sh
+++ b/scripts/create_custom_singularity_modules_from_general_singularity_container_engine.sh
@@ -47,6 +47,12 @@ echo "And using this basis to generate modules in ${dst_dir}"
 mkdir -p ${src_dir}
 cp ${src_old_dir}/*.lua ${src_dir}/
 
+# ensure directory for lua patches (which is referenced in singularity module files) exists
+lmod_patch_dir="${INSTALL_PREFIX}/pawsey/lmod-variable-fixes"
+mkdir -p "$lmod_patch_dir"
+cp "${PAWSEY_SPACK_CONFIG_REPO}/scripts/pawsey_fix_initial_bash.lua" ${lmod_patch_dir}
+cp "${PAWSEY_SPACK_CONFIG_REPO}/scripts/pawsey_init_bash" ${lmod_patch_dir}
+
 # ensure destination directory exists
 mkdir -p ${dst_dir}
 # remove old pawsey singularity modules

--- a/scripts/pawsey_fix_initial_bash.lua
+++ b/scripts/pawsey_fix_initial_bash.lua
@@ -1,0 +1,18 @@
+-- CMEYER: Fix for lmod exectuables being added to FPATH in the `/opt/cray/pe/lmod/lmod/init/bash` file assigned to BASH_ENV:
+-- Read ticket GS-32798
+
+return function(patch_dir)
+
+   local new_bash_env = patch_dir .. "/pawsey_init_bash"
+
+   local bash_env = os.getenv("BASH_ENV")
+   if bash_env then
+      pushenv("BASH_ENV", "")            -- For some reason, this first stacking is needed
+      pushenv("BASH_ENV", bash_env)      -- Stacking entry value
+      pushenv("BASH_ENV", new_bash_env)  -- The value to be used when module is loaded
+   else
+      pushenv("BASH_ENV", "")            -- For some reason, this first stacking is needed
+      pushenv("BASH_ENV", "")            -- Stack entry value
+      pushenv("BASH_ENV", new_bash_env)  -- The value to be used when module is loaded
+   end
+end

--- a/scripts/pawsey_init_bash
+++ b/scripts/pawsey_init_bash
@@ -1,0 +1,199 @@
+#!/bin/bash
+# -*- shell-script -*-
+#
+########################################################################
+# Start Lmod BASHENV
+########################################################################
+
+if [ -z "${LMOD_SH_DBG_ON+x}" ]; then
+   case "$-" in
+     *v*x*) __lmod_vx='vx' ;;
+     *v*)   __lmod_vx='v'  ;;
+     *x*)   __lmod_vx='x'  ;;
+   esac;
+fi
+
+[ -n "${__lmod_vx:-}" ] && set +$__lmod_vx 
+
+if [ -n "${__lmod_vx:-}" ]; then
+    echo "Shell debugging temporarily silenced: export LMOD_SH_DBG_ON=1 for this output (/opt/cray/pe/lmod/lmod/init/bash)" 1>&2
+fi
+
+# CMEYER: The export FPATH line is causing lmod warning messages in singularity shells, replacing this block with that used in previous version of script
+# unset __zsh_fpath
+# if [ -n "${ZSH_VERSION+x}" ] &&  ! (autoload -U compinit && compinit -C 2> /dev/null) ; then
+#   __zsh_fpath=$(unset FPATH; zsh -f -c 'echo $FPATH')
+# fi
+# export FPATH=$(/opt/cray/pe/lmod/lmod/libexec/addto --append FPATH ${__zsh_fpath:-$FPATH} /opt/cray/pe/lmod/lmod/init/ksh_funcs)
+# unset __zsh_fpath
+# FPATH FIX START
+SUPPORT_KSH="no"
+if [ $SUPPORT_KSH = yes -o -n "${KSH_VERSION+x}" ]; then
+   if [ -z "${__LMOD_SET_FPATH+x}" ]; then
+      export FPATH=$(/opt/cray/pe/lmod/lmod/libexec/addto --append FPATH  /opt/cray/pe/lmod/lmod/init/ksh_funcs)
+      export __LMOD_SET_FPATH=1
+   fi
+fi
+unset SUPPORT_KSH
+# FPATH FIX END
+
+export LMOD_ROOT=/opt/cray/pe/lmod
+export LMOD_PKG=/opt/cray/pe/lmod/lmod
+export LMOD_DIR=$LMOD_PKG/libexec
+export LMOD_CMD=$LMOD_PKG/libexec/lmod
+export MODULESHOME=$LMOD_PKG
+export LMOD_SETTARG_FULL_SUPPORT=no
+
+########################################################################
+#  Define the module command:  The first line runs the "lmod" command
+#  to generate text:
+#      export PATH="..."
+#  then the "eval" converts the text into changes in the current shell.
+#
+#  The second command is the settarg command.  Normally LMOD_SETTARG_CMD
+#  is undefined or is ":".  Either way the eval does nothing.  When the
+#  settarg module is loaded, it defines LMOD_SETTARG_CMD.  The settarg
+#  command knows how to read the ModuleTable that Lmod maintains and
+#  generates a series of env. vars that describe the current state of
+#  loaded modules.  So if one is on a x86_64 linux computer with gcc/4.7.2
+#  and openmpi/1.6.3 loaded, then settarg will assign:
+#
+#     TARG=_x86_64_gcc-4.7.2_openmpi-1.6.3
+#     TARG_COMPILER=gcc-4.7.2
+#     TARG_COMPILER_FAMILY=gcc
+#     TARG_MACH=x86_64
+#     TARG_MPI=openmpi-1.6.3
+#     TARG_MPI_FAMILY=openmpi
+#     TARG_SUMMARY=x86_64_gcc-4.7.2_openmpi-1.6.3
+#     TARG_TITLE_BAR=gcc-4.7.2 O-1.6.3
+#     TARG_TITLE_BAR_PAREN=(gcc-4.7.2 O-1.6.3)
+#
+#  unloading openmpi/1.6.3 automatically changes these vars to be:
+#
+#     TARG=_x86_64_gcc-4.6.3
+#     TARG_COMPILER=gcc-4.6.3
+#     TARG_COMPILER_FAMILY=gcc
+#     TARG_MACH=x86_64
+#     TARG_SUMMARY=x86_64_gcc-4.6.3
+#     TARG_TITLE_BAR=gcc-4.6.3
+#     TARG_TITLE_BAR_PAREN=(gcc-4.6.3)
+#
+# See Lmod web site for more details.
+
+
+if [ "yes" = "no" ]; then
+   module()
+   {
+     ############################################################
+     # Run Lmod and eval results
+     eval "$($LMOD_CMD bash "$@")" && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
+   }
+else
+   module()
+   {
+     ############################################################
+     # Silence shell debug UNLESS $LMOD_SH_DBG_ON has a value
+     if [ -z "${LMOD_SH_DBG_ON+x}" ]; then
+        case "$-" in
+          *v*x*) __lmod_sh_dbg='vx' ;;
+          *v*)   __lmod_sh_dbg='v'  ;;
+          *x*)   __lmod_sh_dbg='x'  ;;
+        esac;
+     fi
+     
+     if [ -n "${__lmod_sh_dbg:-}" ]; then
+        set +$__lmod_sh_dbg 
+        echo "Shell debugging temporarily silenced: export LMOD_SH_DBG_ON=1 for Lmod's output" 1>&2
+     fi
+
+     ############################################################
+     # Run Lmod and eval results
+     eval "$($LMOD_CMD shell "$@")" && eval "$(${LMOD_SETTARG_CMD:-:} -s sh)"
+     __lmod_my_status=$?
+
+     ############################################################
+     # Un-silence shell debug after module command
+     if [ -n "${__lmod_sh_dbg:-}" ]; then
+       echo "Shell debugging restarted" 1>&2
+       set -$__lmod_sh_dbg;
+     fi;
+     unset __lmod_sh_dbg
+     return $__lmod_my_status
+   }
+fi
+
+
+LMOD_VERSION="8.7.55"
+export LMOD_VERSION
+
+if [ "${LMOD_SETTARG_CMD:-:}" != ":" ]; then
+  settarg () {
+    eval $(${LMOD_SETTARG_CMD:-:} -s sh "$@" )
+  }
+fi
+
+
+########################################################################
+#  ml is a shorthand tool for people who can't type moduel, err, module
+#  It is also a combination command:
+#     ml            -> module list
+#     ml gcc        -> module load gcc
+#     ml -gcc intel -> module unload gcc; module load intel
+#  It does much more. Do: "ml --help" for more information.
+
+
+unalias ml 2> /dev/null || true
+ml()
+{
+  eval "$($LMOD_DIR/ml_cmd "$@")"
+}
+
+if [ -n "${BASH_VERSION:-}" -a "yes" != no ]; then
+  export -f module
+  export -f ml
+fi
+unset export_module
+
+########################################################################
+#  clearMT removes the ModuleTable from your environment.  It is rarely
+#  needed but it useful sometimes.
+
+clearMT()
+{
+  eval $($LMOD_DIR/clearLMOD_cmd --shell bash --simple)
+}
+
+clearLmod()
+{
+  module --force purge
+  eval $($LMOD_DIR/clearLMOD_cmd --shell bash --full "$@")
+}
+
+xSetTitleLmod()
+{
+  builtin echo -n -e "\033]2;$1\007";
+}
+
+########################################################################
+#  Make tab completions available to bash users.
+
+if [ ${BASH_VERSINFO:-0} -ge 3 ] && [ -r  /opt/cray/pe/lmod/lmod/init/lmod_bash_completions ] && [ -n "${PS1:-}" ] && [ -z "${POSIXLY_CORRECT:-}" ]; then
+ . /opt/cray/pe/lmod/lmod/init/lmod_bash_completions
+fi
+
+
+# Restoring XTRACE and VERBOSE states.
+if [ -n "${__lmod_vx:-}" ]; then
+  echo "Shell debugging restarted" 1>&2
+  set -$__lmod_vx;
+  unset __lmod_vx;
+fi;
+
+########################################################################
+# End Lmod BASHENV
+########################################################################
+#
+# Local Variables:
+# mode: shell-script
+# indent-tabs-mode: nil
+# End:

--- a/systems/setonix/templates/modules/modulefile.lua
+++ b/systems/setonix/templates/modules/modulefile.lua
@@ -178,6 +178,12 @@ setenv("MPICH_GPU_SUPPORT_ENABLED","1")
 setenv("SINGULARITYENV_MPICH_GPU_SUPPORT_ENABLED","1")
 -- add GPUMPI END
 
+-- Patch lmod messages in singularity shells
+local patch_dir = os.getenv("INSTALL_PREFIX") .. "/pawsey/lmod-variable-fixes"
+local patch_file = patch_dir .. "/pawsey_fix_initial_bash.lua"
+local func = assert(loadfile(patch_file))()
+func(patch_dir)
+
 {% endif %}
 {% if spec.name == 'r' %}setenv("R_LIBS_USER", os.getenv("MYSOFTWARE").."/setonix/DATE_TAG/r/%v")
 {% endif %}


### PR DESCRIPTION
Lmod messages like
```
/opt/cray/pe/lmod/lmod/init/bash: line 26: /opt/cray/pe/lmod/lmod/libexec/addto: cannot execute: required file not found
```
are being generated when running certain commands inside singularity shells, due to an upcoming change in the `/opt/cray/pe/lmod/lmod/init/bash` script. This forces the BASH_ENV environment variable to point to the current version of the script when loading singularity, which doesn't trigger these messages, rather than the new version. A ticket for this issue is at GS-32798.

I have tested this setup using separate files from the current installation, and the setting of the env var to point to the different script and subsequent elimination of the lmod messages is working.
