### PR TITLE
Avoiding problems in the OpenFOAM modules

### DIFF
--- a/scripts/patch_shpc_pawsey_modules.sh
+++ b/scripts/patch_shpc_pawsey_modules.sh
@@ -44,6 +44,7 @@ for tool in ${long_dir}/quay.io/pawsey/openfoam* ; do
     if [ -e ${module} ] ; then
       new_conflict="conflict(\"${tool##*/}${shpc_spackuser_container_tag}\")"
       sed --follow-symlinks -i '/conflict(/c '"${new_conflict}"'' ${module}
+      chmod u=rw,go=r ${module} #Recovering the right permissions after sed command
     fi
   done
 done

--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -68,7 +68,7 @@ spack_version="0.23.1" # the prefix "v" is added in setup_spack.sh
 singularity_version="4.1.0-nompi" # has to match the version in the Spack env yaml + nompi tag
 singularity_mpi_version="4.1.0-mpi" # has to match the version in the Spack env yaml + mpi tag
 shpc_version="0.1.32"
-shpc_registry_version="ef423f0310bbac40e4c4b02c2ba0609018f56347"
+shpc_registry_version="bf0d6db12b1fe478e11c53dad966e25bb7d0a1b3"
 
 # python (and py tools) versions
 python_name="python"
@@ -123,6 +123,7 @@ cray_devel
 cray_s3_clients
 "
 #quay.io/sarahbeecroft9/alphafold:2.2.3
+#quay.io/pawsey/alphafold2-amd-gpu:rocm6.1.1
 container_list="
 amazon/aws-cli:2.13.0
 quay.io/biocontainers/bamtools:2.5.2--hd03093a_0
@@ -159,18 +160,17 @@ quay.io/pawsey/openfoam:v2412
 quay.io/pawsey/openfoam:v2212
 quay.io/pawsey/openfoam:v2206
 quay.io/pawsey/openfoam:v2012
-quay.io/pawsey/openfoam:v2006
-quay.io/pawsey/openfoam:v1912
+quay.io/pawsey/openfoam-org:12
 quay.io/pawsey/openfoam-org:10
 quay.io/pawsey/openfoam-org:9
 quay.io/pawsey/openfoam-org:8
-quay.io/pawsey/openfoam-org:7
 quay.io/pawsey/tensorflow:2.15.1-rocm6.3.3
 quay.io/pawsey/tensorflow:2.17-rocm6.3.3
 quay.io/pawsey/pytorch:2.7.1-rocm6.3.3
 quay.io/pawsey/cp2k:2024.3-rocm6.3.0
 quay.io/pawsey/namd:3.0.1
 quay.io/pawsey/namd:3.0.1-rocm6.3.0
+"
 #quay.io/pawsey/hpc-python:2022.03						
 #quay.io/pawsey/hpc-python:2022.03-hdf5mpi
 


### PR DESCRIPTION
Avoiding problems with the sed command when fixing OpenFOAM modules.
Updating the shpc_registry_version inside the setonix/settings.sh file to the latest merge for OpenFOAM settings in shpc.
Updating to the final list of openfoam modules to be deployed in 2025.08 software stack (and setting the closing quotes in the list which, for some reason, was missing.)