### PR TITLE
Update spack_create_user_moduletree.sh

### DIFF
--- a/scripts/templates/spack_create_user_moduletree.sh
+++ b/scripts/templates/spack_create_user_moduletree.sh
@@ -25,8 +25,7 @@ for arch in $archs; do
     mkdir -p "${user_root_dir}/modules/${arch}/${compiler}/${user_modules_suffix}"
   done
 done
-chmod --silent g+rwX "${project_root_dir}"
-chmod --silent -R g+rwX "${project_root_dir}/modules"
+chmod --silent -R g+rwX "${project_root_dir}"
 
 # create shpc user-private container modules base dir (symlinks - views)
 mkdir -p "${user_root_dir}/${shpc_containers_modules_dir}"

--- a/scripts/templates/spack_create_user_moduletree.sh
+++ b/scripts/templates/spack_create_user_moduletree.sh
@@ -25,7 +25,6 @@ for arch in $archs; do
     mkdir -p "${user_root_dir}/modules/${arch}/${compiler}/${user_modules_suffix}"
   done
 done
-chmod --silent -R g+rwX "${project_root_dir}"
 
 # create shpc user-private container modules base dir (symlinks - views)
 mkdir -p "${user_root_dir}/${shpc_containers_modules_dir}"
@@ -73,3 +72,5 @@ mkdir -p "${user_root_dir}/r/${r_version_majorminor}"
 
 # create empty control file
 touch ${user_root_dir}/.created_moduletree_bases
+
+chmod --silent -R g+rwX "${project_root_dir}"


### PR DESCRIPTION
All project members should be able to write to the project-wide installation dir, not only modules, but also software and containers. See #328