### PR TITLE
Clones the builtin repo under /vat/spack/repos

### DIFF
--- a/systems/setonix/configs/site/repos.yaml
+++ b/systems/setonix/configs/site/repos.yaml
@@ -4,12 +4,15 @@ repos:
 # and take precedence
 #
 # This one is for user recipes
-- USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/spack_repo
+  user_repo: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/$USER/setonix/DATE_TAG/spack_repo
 
 # The following is for project-wide recipes
-- USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG/spack_repo
+  project_repo: USER_PERMANENT_FILES_PREFIX/$PAWSEY_PROJECT/setonix/DATE_TAG/spack_repo
 
 # 
 # Spack user (Pawsey staff) populates this one with fixed recipes for Setonix
 # that are not (yet) in the Spack public repo
-- INSTALL_PREFIX/spack/var/spack/repos/pawsey
+  pawsey_repo: INSTALL_PREFIX/spack/var/spack/repos/pawsey
+
+  builtin:
+    destination: INSTALL_PREFIX/spack/var/spack/repos/builtin


### PR DESCRIPTION
With Spack 1.0 the builtin repository of packages is now separated from the Spack codebase. It is cloned automatically under ~/.spack by default. This commit brings back the download location under spack/var/spack/repos.

This commit also updates the syntax used to specify repositories as key:value pairs.