### PR TITLE
Update set_licensing_permissions.sh

### DIFF
--- a/scripts/set_licensing_permissions.sh
+++ b/scripts/set_licensing_permissions.sh
@@ -57,7 +57,7 @@ else
 fi
 
 # Spack installations
-for package in amber ansys-fluids cpmd namd vasp@5 vasp@6 ; do
+for package in amber ansys-fluids namd vasp@5 vasp@6 ; do
   software_dirs=$( spack find -p $package |grep ^${package} |tr -s ' ' |cut -d ' ' -f 2 )
   module_dirs=""
   if [ "${package}" == "vasp@6" ] ; then


### PR DESCRIPTION
The CPMD is freely distributed under the MIT License, so no need to add it to cpmd ldap group anymore.