### PR TITLE
mwa stack, June 2026

### DIFF
--- a/repo/packages/birli/package.py
+++ b/repo/packages/birli/package.py
@@ -10,6 +10,7 @@ class Birli(Package):
     maintainers = ["d3v-null", "gsleap"]
 
     version("main", branch="main")
+    version("0.19.0", tag="v0.19.0")
     version("0.18.2", tag="v0.18.2")
     version("0.17.1", tag="v0.17.1")
     version("0.16.0", tag="v0.16.0")
@@ -26,6 +27,7 @@ class Birli(Package):
 
     depends_on("rust@1.64.0:", type="build")
     depends_on("rust@1.65.0:", type="build", when="@0.16.0:")
+    depends_on("rust@1.85.0:", type="build", when="@0.19.0:")
     depends_on("cmake", type="build")
 
     # cfitsio > 4 introduces a breaking change, is incompatible with mwalib.

--- a/repo/packages/birli/package.py
+++ b/repo/packages/birli/package.py
@@ -10,6 +10,7 @@ class Birli(Package):
     maintainers = ["d3v-null", "gsleap"]
 
     version("main", branch="main")
+    version("0.19.1", tag="v0.19.1")
     version("0.19.0", tag="v0.19.0")
     version("0.18.2", tag="v0.18.2")
     version("0.17.1", tag="v0.17.1")
@@ -45,7 +46,7 @@ class Birli(Package):
         if self.spec.satisfies("+cfitsio-static"):
             env.set("MWALIB_LINK_STATIC_CFITSIO", 1)
         if self.spec.satisfies("~portable"):
-            env.append_flags("RUSTFLAGS", f"-C target-cpu=native")
+            env.append_flags("RUSTFLAGS", "-C target-cpu=native")
 
     def get_features(self):
         features = ["cli"]

--- a/repo/packages/giant-squid/package.py
+++ b/repo/packages/giant-squid/package.py
@@ -15,10 +15,12 @@ class GiantSquid(Package):
 
     maintainers = ["gsleap", "d3v-null"]
 
+    version("2.5.1", tag="v2.5.1")
     version("2.3.0", tag="v2.3.0")
     version("2.2.0", tag="v2.2.0")
-        
+
     depends_on("rust@1.82:", when="@2.2.0:", type="build")
+    depends_on("rust@1.85.0:", when="@2.5.1:", type="build") # actually 2.4.0:
 
     def setup_build_environment(self, env):
         build_dir = self.stage.source_path

--- a/repo/packages/hyperbeam/package.py
+++ b/repo/packages/hyperbeam/package.py
@@ -21,6 +21,7 @@ class Hyperbeam(Package, ROCmPackage, CudaPackage):
     maintainers = ["d3v-null", "gsleap"]
 
     version("main", branch="main")
+    version("0.11.0", tag="v0.11.0")
     version("0.10.2", tag="v0.10.2")
     version("0.10.0", tag="v0.10.0")
     version("0.9.3", tag="v0.9.3")
@@ -35,6 +36,7 @@ class Hyperbeam(Package, ROCmPackage, CudaPackage):
 
     depends_on("rust@1.64.0:", type="build")
     depends_on("rust@1.80.0:", type="build", when="@0.10.0:")
+    depends_on("rust@1.85.0:", type="build", when="@0.11.0:")
     depends_on("cmake", type="build")
 
     # cfitsio > 4 introduces a breaking change, is incompatible with mwalib.

--- a/repo/packages/hyperdrive/package.py
+++ b/repo/packages/hyperdrive/package.py
@@ -10,6 +10,8 @@ class Hyperdrive(Package, ROCmPackage, CudaPackage):
     maintainers = ["d3v-null", "gsleap"]
 
     version("main", branch="main")
+    version("0.8.0", tag="v0.8.0")
+    version("0.7.0", tag="v0.7.0")
     version("0.6.1", tag="v0.6.1")
     version("0.6.1-devel", tag="v0.6.1-devel")
     version("0.6.1-autos", tag="v0.6.1-autos")
@@ -25,6 +27,7 @@ class Hyperdrive(Package, ROCmPackage, CudaPackage):
 
     depends_on("rust@1.64.0:")
     depends_on("rust@1.80.0:", when="@0.5.0:")
+    depends_on("rust@1.85.0:", when="@0.8.0:")
     depends_on("cmake", type="build")
     # cfitsio > 4 introduces a breaking change, is incompatible with mwalib.
     # default spack cfitsio does not give the +reentrant option

--- a/repo/packages/mwalib/package.py
+++ b/repo/packages/mwalib/package.py
@@ -21,6 +21,7 @@ class Mwalib(Package):
     maintainers = ["gsleap", "d3v-null"]
 
     version("main", branch="main")
+    version("2.0.5", tag="v2.0.5")
     version("1.8.7", tag="v1.8.7")
     version("1.8.2", tag="v1.8.2")
     version("1.5.0", tag="v1.5.0")
@@ -35,6 +36,7 @@ class Mwalib(Package):
 
     depends_on("rust@1.64.0:", type="build")
     depends_on("rust@1.65.0:", type="build", when="@1.8:")
+    depends_on("rust@1.85.0:", type="build", when="@2.0.5:")
 
     # cfitsio > 4 introduces a breaking change, is incompatible with mwalib.
     # default spack cfitsio does not give the +reentrant option

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -53,7 +53,7 @@ spack:
               - hyperbeam@0.10.2 ~portable +python
               - hyperdrive@=0.8.0 ~portable
               - hyperdrive@=0.7.0 ~portable
-              - birli@0.19.0 +aoflagger ~portable
+              - birli@0.19.1 +aoflagger ~portable
               - birli@0.18.2 +aoflagger ~portable
               - calceph@3.5.5 target=zen3
               - presto@5.0.1 target=zen3

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -4,115 +4,115 @@
 # configuration settings.
 # Pawsey, Ilkhom: giant-squid@1.0.3 is moved to mwa-no-python to avoid concretization error.
 spack:
-  packages:
-    "blas:":
-      buildable: true
-    "lapack:":
-      buildable: true
-    "fftw-api:":
-      buildable: true
-  definitions:
-    # casacore variants
-    # try running spack install --no-checksum
-    - casacore-legacy:
-        - casacore@3.2.1 +python datapath=setonix build_type=Release ^python@3.11.6 # no checksum for this release
-    - casacore-set:
-        - casacore@3.3.0 datapath=setonix
-        - casacore@3.4.0 datapath=setonix
-    - casacore-new-set:
-        - casacore@3.5.0 +openmp+python+hdf5 datapath=setonix build_type=Release
-    - astro-util-set:
-        - cfitsio@3.49 +reentrant
-        - cfitsio@4.4.0 +reentrant
-        - wcslib +cfitsio
-        - wcslib ~cfitsio
-        - pgplot
-        - wcstools
-    - askap-util-set:
-        - cppzmq
-        - libzmq
-        - apr
-        - apr-util
-        - gsl
-        - cppunit
-        - log4cxx cxxstd=17
-        - log4cxx cxxstd=11 ^python@3.11.6
-        - mcpp
-        - xerces-c transcoder=gnuiconv
-        - xerces-c transcoder=iconv
-        - subversion
+    packages:
+        "blas:":
+            buildable: true
+        "lapack:":
+            buildable: true
+        "fftw-api:":
+            buildable: true
+    definitions:
+        # casacore variants
+        # try running spack install --no-checksum
+        - casacore-legacy:
+              - casacore@3.2.1 +python datapath=setonix build_type=Release ^python@3.11.6 # no checksum for this release
+        - casacore-set:
+              - casacore@3.3.0 datapath=setonix
+              - casacore@3.4.0 datapath=setonix
+        - casacore-new-set:
+              - casacore@3.5.0 +openmp+python+hdf5 datapath=setonix build_type=Release
+        - astro-util-set:
+              - cfitsio@3.49 +reentrant
+              - cfitsio@4.4.0 +reentrant
+              - wcslib +cfitsio
+              - wcslib ~cfitsio
+              - pgplot
+              - wcstools
+        - askap-util-set:
+              - cppzmq
+              - libzmq
+              - apr
+              - apr-util
+              - gsl
+              - cppunit
+              - log4cxx cxxstd=17
+              - log4cxx cxxstd=11 ^python@3.11.6
+              - mcpp
+              - xerces-c transcoder=gnuiconv
+              - xerces-c transcoder=iconv
+              - subversion
 
-    - mwa-with-python:
-        - wsclean@3.4 +mpi +idg +everybeam build_type=Release target=zen3
-        - wsclean@3.4 ~mpi +idg +everybeam build_type=Release target=zen3
-        - wsclean@2.9 +idg build_type=Release target=zen3
-        - mwalib@2.0.5+python~portable
-        - mwalib@1.8.7+python~portable
-        - aoflagger@3.4.0 build_type=Release target=zen3 ^cfitsio@3.49
-        - hyperbeam@0.11.0 ~portable +python
-        - hyperbeam@0.10.2 ~portable +python
-        - hyperdrive@=0.8.0 ~portable
-        - hyperdrive@=0.6.1 ~portable
-        - birli@0.19.0 +aoflagger ~portable
-        - birli@0.18.2 +aoflagger ~portable
-        - calceph@3.5.5 target=zen3
-        - presto@5.0.1 target=zen3
+        - mwa-with-python:
+              - wsclean@3.4 +mpi +idg +everybeam build_type=Release target=zen3
+              - wsclean@3.4 ~mpi +idg +everybeam build_type=Release target=zen3
+              - wsclean@2.9 +idg build_type=Release target=zen3
+              - mwalib@2.0.5+python~portable
+              - mwalib@1.8.7+python~portable
+              - aoflagger@3.4.0 build_type=Release target=zen3 ^cfitsio@3.49
+              - hyperbeam@0.11.0 ~portable +python
+              - hyperbeam@0.10.2 ~portable +python
+              - hyperdrive@=0.8.0 ~portable
+              - hyperdrive@=0.7.0 ~portable
+              - birli@0.19.0 +aoflagger ~portable
+              - birli@0.18.2 +aoflagger ~portable
+              - calceph@3.5.5 target=zen3
+              - presto@5.0.1 target=zen3
 
-    - mwa-no-python:
-        - chgcentre build_type=Release target=zen3
-        - giant-squid@2.5.1 target=zen3
-        - giant-squid@2.5.1 target=zen2
-        - giant-squid@2.3.0 target=zen3
-        - giant-squid@2.3.0 target=zen2
+        - mwa-no-python:
+              - chgcentre build_type=Release target=zen3
+              - giant-squid@2.5.1 target=zen3
+              - giant-squid@2.5.1 target=zen2
+              - giant-squid@2.3.0 target=zen3
+              - giant-squid@2.3.0 target=zen2
 
-    # TODO add versions
-    - python-astro-set:
-        - py-funcsigs #package not available in spack/0.20.0, using recipe from 0.19.0
-        - py-astropy@4.2.1+extras
-        - py-astropy@5.1+extras
-          #    - py-healpy ^py-astropy@4.2.1+extras #No longintrepr.h in python/3.11
-        - py-emcee
-  # add package specs to the `specs` list
-  specs:
-    - matrix:
-        - [$casacore-set]
-        - ["%gcc@14.2.0"]
-        - [target=zen3]
-        - [+python build_type=Release ^python@3.11.6]
-        - [+openmp, ~openmp]
-        - [
-            ~adios2 ~hdf5,
-            +adios2 +hdf5 ^adios2@2.8.3 +hdf5 ^hdf5@1.12.2 +hl +fortran
-            build_type=Release +szip api=v112,
-          ]
-          # can't use hdf%@1.14.3 for casacore yet
-    - matrix:
-        - [$casacore-legacy]
-        - ["%gcc@14.2.0"]
-        - [target=zen3]
-    - matrix:
-        - [$astro-util-set, $askap-util-set]
-        - ["%gcc@14.2.0"]
-        - [target=zen3]
+        # TODO add versions
+        - python-astro-set:
+              - py-funcsigs #package not available in spack/0.20.0, using recipe from 0.19.0
+              - py-astropy@4.2.1+extras
+              - py-astropy@5.1+extras
+                #    - py-healpy ^py-astropy@4.2.1+extras #No longintrepr.h in python/3.11
+              - py-emcee
+    # add package specs to the `specs` list
+    specs:
+        - matrix:
+              - [$casacore-set]
+              - ["%gcc@14.2.0"]
+              - [target=zen3]
+              - [+python build_type=Release ^python@3.11.6]
+              - [+openmp, ~openmp]
+              - [
+                    ~adios2 ~hdf5,
+                    +adios2 +hdf5 ^adios2@2.8.3 +hdf5 ^hdf5@1.12.2 +hl +fortran
+                    build_type=Release +szip api=v112,
+                ]
+                # can't use hdf%@1.14.3 for casacore yet
+        - matrix:
+              - [$casacore-legacy]
+              - ["%gcc@14.2.0"]
+              - [target=zen3]
+        - matrix:
+              - [$astro-util-set, $askap-util-set]
+              - ["%gcc@14.2.0"]
+              - [target=zen3]
 
-    - matrix:
-        - [$mwa-no-python]
-        - ["%gcc@14.2.0"]
+        - matrix:
+              - [$mwa-no-python]
+              - ["%gcc@14.2.0"]
 
-    - matrix:
-        - [$mwa-with-python]
-        - [^python@3.11.6]
-        - ["%gcc@14.2.0"]
+        - matrix:
+              - [$mwa-with-python]
+              - [^python@3.11.6]
+              - ["%gcc@14.2.0"]
 
-    - matrix:
-        - [$python-astro-set]
-        - [^python@3.11.6]
-        - ["%gcc@14.2.0"]
-        - [target=zen3]
-    - matrix:
-        - [$casacore-new-set]
-        - [^python@3.11.6]
-        - [^boost@1.83.0]
-        - ["%gcc@14.2.0"]
-        - [target=zen3]
-  view: false
+        - matrix:
+              - [$python-astro-set]
+              - [^python@3.11.6]
+              - ["%gcc@14.2.0"]
+              - [target=zen3]
+        - matrix:
+              - [$casacore-new-set]
+              - [^python@3.11.6]
+              - [^boost@1.83.0]
+              - ["%gcc@14.2.0"]
+              - [target=zen3]
+    view: false

--- a/systems/setonix/environments/astro/spack.yaml
+++ b/systems/setonix/environments/astro/spack.yaml
@@ -5,106 +5,114 @@
 # Pawsey, Ilkhom: giant-squid@1.0.3 is moved to mwa-no-python to avoid concretization error.
 spack:
   packages:
-    'blas:':
+    "blas:":
       buildable: true
-    'lapack:':
+    "lapack:":
       buildable: true
-    'fftw-api:':
+    "fftw-api:":
       buildable: true
   definitions:
+    # casacore variants
+    # try running spack install --no-checksum
+    - casacore-legacy:
+        - casacore@3.2.1 +python datapath=setonix build_type=Release ^python@3.11.6 # no checksum for this release
+    - casacore-set:
+        - casacore@3.3.0 datapath=setonix
+        - casacore@3.4.0 datapath=setonix
+    - casacore-new-set:
+        - casacore@3.5.0 +openmp+python+hdf5 datapath=setonix build_type=Release
+    - astro-util-set:
+        - cfitsio@3.49 +reentrant
+        - cfitsio@4.4.0 +reentrant
+        - wcslib +cfitsio
+        - wcslib ~cfitsio
+        - pgplot
+        - wcstools
+    - askap-util-set:
+        - cppzmq
+        - libzmq
+        - apr
+        - apr-util
+        - gsl
+        - cppunit
+        - log4cxx cxxstd=17
+        - log4cxx cxxstd=11 ^python@3.11.6
+        - mcpp
+        - xerces-c transcoder=gnuiconv
+        - xerces-c transcoder=iconv
+        - subversion
 
-  # casacore variants
-  # try running spack install --no-checksum
-  - casacore-legacy:
-    - casacore@3.2.1 +python datapath=setonix build_type=Release ^python@3.11.6 # no checksum for this release
-  - casacore-set:
-    - casacore@3.3.0 datapath=setonix
-    - casacore@3.4.0 datapath=setonix
-  - casacore-new-set:
-    - casacore@3.5.0 +openmp+python+hdf5 datapath=setonix build_type=Release
-  - astro-util-set:
-    - cfitsio@3.49 +reentrant
-    - cfitsio@4.4.0 +reentrant
-    - wcslib +cfitsio
-    - wcslib ~cfitsio
-    - pgplot
-    - wcstools
-  - askap-util-set:
-    - cppzmq
-    - libzmq
-    - apr
-    - apr-util
-    - gsl
-    - cppunit
-    - log4cxx cxxstd=17
-    - log4cxx cxxstd=11 ^python@3.11.6
-    - mcpp
-    - xerces-c transcoder=gnuiconv
-    - xerces-c transcoder=iconv
-    - subversion
+    - mwa-with-python:
+        - wsclean@3.4 +mpi +idg +everybeam build_type=Release target=zen3
+        - wsclean@3.4 ~mpi +idg +everybeam build_type=Release target=zen3
+        - wsclean@2.9 +idg build_type=Release target=zen3
+        - mwalib@2.0.5+python~portable
+        - mwalib@1.8.7+python~portable
+        - aoflagger@3.4.0 build_type=Release target=zen3 ^cfitsio@3.49
+        - hyperbeam@0.11.0 ~portable +python
+        - hyperbeam@0.10.2 ~portable +python
+        - hyperdrive@=0.8.0 ~portable
+        - hyperdrive@=0.6.1 ~portable
+        - birli@0.19.0 +aoflagger ~portable
+        - birli@0.18.2 +aoflagger ~portable
+        - calceph@3.5.5 target=zen3
+        - presto@5.0.1 target=zen3
 
-  - mwa-with-python:
-    - wsclean@3.4 +mpi +idg +everybeam build_type=Release target=zen3
-    - wsclean@3.4 ~mpi +idg +everybeam build_type=Release target=zen3
-    - wsclean@2.9 +idg build_type=Release target=zen3
-    - mwalib@1.8.7+python~portable
-    - aoflagger@3.4.0 build_type=Release target=zen3 ^cfitsio@3.49
-    - hyperbeam@0.10.2 ~portable +python
-    - hyperdrive@=0.6.1 ~portable
-    - birli@0.18.2 +aoflagger ~portable
-    - calceph@3.5.5 target=zen3
-    - presto@5.0.1 target=zen3
+    - mwa-no-python:
+        - chgcentre build_type=Release target=zen3
+        - giant-squid@2.5.1 target=zen3
+        - giant-squid@2.5.1 target=zen2
+        - giant-squid@2.3.0 target=zen3
+        - giant-squid@2.3.0 target=zen2
 
-  - mwa-no-python:
-    - chgcentre build_type=Release target=zen3
-    - giant-squid@2.3.0 target=zen3
-    - giant-squid@2.3.0 target=zen2
-
-  # TODO add versions
-  - python-astro-set:
-    - py-funcsigs #package not available in spack/0.20.0, using recipe from 0.19.0
-    - py-astropy@4.2.1+extras
-    - py-astropy@5.1+extras
-      #    - py-healpy ^py-astropy@4.2.1+extras #No longintrepr.h in python/3.11
-    - py-emcee
+    # TODO add versions
+    - python-astro-set:
+        - py-funcsigs #package not available in spack/0.20.0, using recipe from 0.19.0
+        - py-astropy@4.2.1+extras
+        - py-astropy@5.1+extras
+          #    - py-healpy ^py-astropy@4.2.1+extras #No longintrepr.h in python/3.11
+        - py-emcee
   # add package specs to the `specs` list
   specs:
-  - matrix:
-    - [$casacore-set]
-    - ['%gcc@14.2.0']
-    - [target=zen3]
-    - [+python build_type=Release ^python@3.11.6]
-    - [+openmp, ~openmp]
-    - [~adios2 ~hdf5, +adios2 +hdf5 ^adios2@2.8.3 +hdf5 ^hdf5@1.12.2 +hl +fortran
-        build_type=Release +szip api=v112]
-        # can't use hdf%@1.14.3 for casacore yet
-  - matrix:
-    - [$casacore-legacy]
-    - ['%gcc@14.2.0']
-    - [target=zen3]
-  - matrix:
-    - [$astro-util-set, $askap-util-set]
-    - ['%gcc@14.2.0']
-    - [target=zen3]
+    - matrix:
+        - [$casacore-set]
+        - ["%gcc@14.2.0"]
+        - [target=zen3]
+        - [+python build_type=Release ^python@3.11.6]
+        - [+openmp, ~openmp]
+        - [
+            ~adios2 ~hdf5,
+            +adios2 +hdf5 ^adios2@2.8.3 +hdf5 ^hdf5@1.12.2 +hl +fortran
+            build_type=Release +szip api=v112,
+          ]
+          # can't use hdf%@1.14.3 for casacore yet
+    - matrix:
+        - [$casacore-legacy]
+        - ["%gcc@14.2.0"]
+        - [target=zen3]
+    - matrix:
+        - [$astro-util-set, $askap-util-set]
+        - ["%gcc@14.2.0"]
+        - [target=zen3]
 
-  - matrix:
-    - [ $mwa-no-python]
-    - ['%gcc@14.2.0']
+    - matrix:
+        - [$mwa-no-python]
+        - ["%gcc@14.2.0"]
 
-  - matrix:
-    - [$mwa-with-python]
-    - [^python@3.11.6]
-    - ['%gcc@14.2.0']
+    - matrix:
+        - [$mwa-with-python]
+        - [^python@3.11.6]
+        - ["%gcc@14.2.0"]
 
-  - matrix:
-    - [$python-astro-set]
-    - [^python@3.11.6]
-    - ['%gcc@14.2.0']
-    - [target=zen3]
-  - matrix:
-    - [$casacore-new-set]
-    - [^python@3.11.6]
-    - [^boost@1.83.0]
-    - ['%gcc@14.2.0']
-    - [target=zen3]
+    - matrix:
+        - [$python-astro-set]
+        - [^python@3.11.6]
+        - ["%gcc@14.2.0"]
+        - [target=zen3]
+    - matrix:
+        - [$casacore-new-set]
+        - [^python@3.11.6]
+        - [^boost@1.83.0]
+        - ["%gcc@14.2.0"]
+        - [target=zen3]
   view: false


### PR DESCRIPTION
* Updated packages:
  * mwalib 2.0.5
  * Birli 0.19.0
  * giant-squid 2.5.1
  * hyperbeam 0.11.0
  * hyperdrive 0.8.0 and 0.7.0

* Updated astro:
  * Add all the above new versions, kept previous versions.