### PR TITLE
Multi-arch `pawseyenv` template

### DIFF
--- a/scripts/install_spack.sh
+++ b/scripts/install_spack.sh
@@ -152,8 +152,15 @@ for mod_cat in $module_cat_list ; do
   module_lua_cat_list+="\"$mod_cat\", "
 done
 
+# Generate the suffixes used by the Cray Lmod compiler hierarchy variables.
+gcc_lmod_ver="${gcc_compat_version//./_}"
+cce_lmod_ver="${cce_compat_version//./_}"
+aocc_lmod_ver="${aocc_compat_version//./_}"
+nvidia_lmod_ver="${nvidia_compat_version//./_}"
+
 sed \
   -e "s|INSTALL_PREFIX|${INSTALL_PREFIX}|g"\
+  -e "s|SYSTEM|${SYSTEM}|g"\
   -e "s|DATE_TAG|$DATE_TAG|g"\
   -e "s|USER_PERMANENT_FILES_PREFIX|${USER_PERMANENT_FILES_PREFIX}|g"\
   -e "s;CUSTOM_MODULES_DIR;${custom_modules_dir};g" \
@@ -165,8 +172,11 @@ sed \
   -e "s;GCC_VERSION;${gcc_version};g" \
   -e "s;CCE_VERSION;${cce_version};g" \
   -e "s;AOCC_VERSION;${aocc_version};g" \
+  -e "s;NVIDIA_VERSION;${nvidia_version};g" \
+  -e "s;GCC_LMOD_VERSION;${gcc_lmod_ver};g" \
+  -e "s;CCE_LMOD_VERSION;${cce_lmod_ver};g" \
+  -e "s;AOCC_LMOD_VERSION;${aocc_lmod_ver};g" \
+  -e "s;NVIDIA_LMOD_VERSION;${nvidia_lmod_ver};g" \
   -e "s;MODULE_LUA_CAT_LIST;${module_lua_cat_list};g" \
   ${PAWSEY_SPACK_CONFIG_REPO}/scripts/templates/pawseyenv.lua \
   > "${INSTALL_PREFIX}/staff_modulefiles/pawseyenv/${pawseyenv_version}.lua"
-
-

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -4,116 +4,223 @@
 
 --[[
 
-    A set of variable definitions to handle software 
-    modules on Setonix, including Lmod hierarchies for 
-    compilers and CPU architectures. Note that this 
-    module needs to be loaded before the compiler module.
+    A set of variable definitions to handle software
+    modules on Setonix, including Lmod hierarchies for
+    compilers and CPU architectures. This module must be
+    loaded before the compiler module.
 
 ]]--
 
-local shl_user = os.getenv("USER")
+local user = os.getenv("USER")
+if user == "root" then
+  return
+end
 
-if not (shl_user == "root") then
-prepend_path('LMOD_PACKAGE_PATH', '/software/setonix/lmod-extras')
+family("pawseyenv")
 
--- Service variables for this module
--- 
---
-local fh = assert(io.open(os.getenv("HOME") .. "/.pawsey_project", "r"))
-local psc_sw_env_project = fh:read("l")
-fh:close()
-local psc_sw_env_user = os.getenv("USER")
--- 
--- NOTE: all definitions below need to be kept in sync with the
--- corresponding values found in `variables.sh` in this same directory
--- 
--- This is handy for testing, as it is the only one to tweak
-local psc_sw_env_root_dir = "INSTALL_PREFIX"
--- 
-local psc_sw_env_custom_modules_dir = "CUSTOM_MODULES_DIR"
-local psc_sw_env_utilities_modules_dir = "UTILITIES_MODULES_DIR"
-local psc_sw_env_shpc_containers_modules_dir = "SHPC_CONTAINERS_MODULES_DIR"
---
-local psc_sw_env_custom_modules_suffix = "CUSTOM_MODULES_SUFFIX"
-local psc_sw_env_project_modules_suffix = "PROJECT_MODULES_SUFFIX"
-local psc_sw_env_user_modules_suffix = "USER_MODULES_SUFFIX"
--- 
--- These need to be checked at every OS update
-local psc_sw_env_gcc_version  = "GCC_VERSION"
-local psc_sw_env_cce_version  = "CCE_VERSION"
-local psc_sw_env_aocc_version = "AOCC_VERSION"
+--------------------------------------------------------------------------------
+-- Runtime Detection
+--------------------------------------------------------------------------------
+local host_arch = subprocess("uname -m")
+local arch
 
--- List of Spack module categories
--- update when new categories are added
-local psc_sw_env_module_categories = {
+if string.match(host_arch, "aarch64") then
+  arch = "neoverse_v2"
+else
+  local cpu_model = subprocess("lscpu | grep 'Model name'")
+  if string.match(cpu_model, "7..3") then
+    arch = "zen3"
+  else
+    arch = "zen2"
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Configuration: sed-replaced template values
+--------------------------------------------------------------------------------
+local install_prefix = "INSTALL_PREFIX"
+local system = "SYSTEM"
+local date_tag = "DATE_TAG"
+local user_permanent_files_prefix = "USER_PERMANENT_FILES_PREFIX"
+
+local custom_modules_dir = "CUSTOM_MODULES_DIR"
+local utilities_modules_dir = "UTILITIES_MODULES_DIR"
+local shpc_modules_dir = "SHPC_CONTAINERS_MODULES_DIR"
+
+local custom_modules_suffix = "CUSTOM_MODULES_SUFFIX"
+local project_modules_suffix = "PROJECT_MODULES_SUFFIX"
+local user_modules_suffix = "USER_MODULES_SUFFIX"
+
+local gcc_version = "GCC_VERSION"
+local cce_version = "CCE_VERSION"
+local aocc_version = "AOCC_VERSION"
+local nvidia_version = "NVIDIA_VERSION"
+
+local module_categories = {
   MODULE_LUA_CAT_LIST
 }
--- Count how many categories
-num_categories = 0
-for _ in pairs(psc_sw_env_module_categories) do num_categories = num_categories + 1 end
 
--- Query CPU architecture
-local psc_sw_env_host_cpu = subprocess("lscpu | grep 'Model name'")
-if ( string.match(psc_sw_env_host_cpu, "7..3") ~= nil ) then
-  arch = "zen3"
-else
-  arch = "zen2"
+--------------------------------------------------------------------------------
+-- Architecture and Compiler Configuration
+--------------------------------------------------------------------------------
+local is_zen_arch = arch == "zen2" or arch == "zen3"
+local compilers = {}
+
+local function add_compiler(alias, compatible_version, dir, version, enabled)
+  if enabled and version ~= "" then
+    table.insert(compilers, {
+      var = "LMOD_CUSTOM_COMPILER_"
+        .. alias .. "_" .. compatible_version .. "_PREFIX",
+      dir = dir,
+      version = version
+    })
+  end
 end
 
+add_compiler("GNU", "GCC_LMOD_VERSION", "gcc", gcc_version, true)
+add_compiler("CRAYCLANG", "CCE_LMOD_VERSION", "cce", cce_version, is_zen_arch)
+add_compiler("AOCC", "AOCC_LMOD_VERSION", "aocc", aocc_version, is_zen_arch)
+add_compiler(
+  "NVIDIA", "NVIDIA_LMOD_VERSION", "nvhpc", nvidia_version,
+  arch == "neoverse_v2"
+)
 
--- Add User modules to Cray Lmod hierarchy variables
--- Compiler modulefiles: /opt/cray/pe/lmod/modulefiles/core/<compiler>/<version>.lua
--- Cray service functions: /opt/cray/pe/admin-pe/lmod_scripts/lmodHierarchy.lua
-local psc_sw_env_user_modules_root =  "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/" .. psc_sw_env_user .. "/setonix/DATE_TAG/modules/" .. arch
-prepend_path("LMOD_CUSTOM_COMPILER_GNU_12_0_PREFIX", psc_sw_env_user_modules_root .. "/gcc/" .. psc_sw_env_gcc_version .. "/" .. psc_sw_env_user_modules_suffix)
-prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_17_0_PREFIX", psc_sw_env_user_modules_root .. "/cce/" .. psc_sw_env_cce_version .. "/" .. psc_sw_env_user_modules_suffix)
-prepend_path("LMOD_CUSTOM_COMPILER_AOCC_4_1_PREFIX", psc_sw_env_user_modules_root .. "/aocc/" .. psc_sw_env_aocc_version .. "/" .. psc_sw_env_user_modules_suffix)
+--------------------------------------------------------------------------------
+-- Cross-partition Cleanup
+--------------------------------------------------------------------------------
+local current_mode = mode()
 
-
--- Add User SHPC modules to MODULEPATH
-local psc_sw_env_shpc_user_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/" .. psc_sw_env_user .. "/setonix/DATE_TAG/" .. psc_sw_env_shpc_containers_modules_dir
-prepend_path("MODULEPATH", psc_sw_env_shpc_user_root)
- -- and the project-wide SHPC modules..
-local psc_sw_env_shpc_project_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/setonix/DATE_TAG/" .. psc_sw_env_shpc_containers_modules_dir
-prepend_path("MODULEPATH", psc_sw_env_shpc_project_root)
-
--- Add Project modules to Cray Lmod hierarchy variables
-local psc_sw_env_project_modules_root = "USER_PERMANENT_FILES_PREFIX/" .. psc_sw_env_project .. "/setonix/DATE_TAG/modules/" .. arch
-prepend_path("LMOD_CUSTOM_COMPILER_GNU_12_0_PREFIX", psc_sw_env_project_modules_root .. "/gcc/" .. psc_sw_env_gcc_version .. "/" .. psc_sw_env_project_modules_suffix)
-prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_17_0_PREFIX", psc_sw_env_project_modules_root .. "/cce/" .. psc_sw_env_cce_version .. "/" .. psc_sw_env_project_modules_suffix)
-prepend_path("LMOD_CUSTOM_COMPILER_AOCC_4_1_PREFIX", psc_sw_env_project_modules_root .. "/aocc/" .. psc_sw_env_aocc_version .. "/" .. psc_sw_env_project_modules_suffix)
-
-
--- Add Pawsey utility modules (including Spack/SHPC modulefiles) to MODULEPATH
-local psc_sw_env_utilities_modules_root = psc_sw_env_root_dir .. "/" .. psc_sw_env_utilities_modules_dir
-prepend_path("MODULEPATH", psc_sw_env_utilities_modules_root)
-
-
--- Root directories for Spack modules
-local psc_sw_env_spack_root = psc_sw_env_root_dir .. "/modules/" .. arch
-local psc_sw_env_gcc_root  = psc_sw_env_spack_root .. "/gcc/" .. psc_sw_env_gcc_version
-local psc_sw_env_cce_root  = psc_sw_env_spack_root .. "/cce/" .. psc_sw_env_cce_version
-local psc_sw_env_aocc_root = psc_sw_env_spack_root .. "/aocc/" .. psc_sw_env_aocc_version
--- Add Spack modules to Cray Lmod hierarchy variables
--- Note: LMOD_CUSTOM_COMPILER_GNU_8_0_PREFIX comes from Lumi, on Joey there was no `_8_0`
-for index = 1,num_categories do
-  prepend_path("LMOD_CUSTOM_COMPILER_GNU_12_0_PREFIX", psc_sw_env_gcc_root .. "/" .. psc_sw_env_module_categories[index])
-  prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_17_0_PREFIX", psc_sw_env_cce_root .. "/" .. psc_sw_env_module_categories[index])
-  prepend_path("LMOD_CUSTOM_COMPILER_AOCC_4_1_PREFIX", psc_sw_env_aocc_root .. "/" .. psc_sw_env_module_categories[index])
+local function contains(path, fragment)
+  return string.find(path, fragment, 1, true) ~= nil
 end
 
+local function is_stale_partition_path(path)
+  if arch == "neoverse_v2" then
+    return contains(path, "/setonix/")
+      or contains(path, "/zen2/")
+      or contains(path, "/zen3/")
+  elseif arch == "zen3" then
+    return contains(path, "/setonix-q/")
+      or contains(path, "/neoverse_v2/")
+      or contains(path, "/zen2/")
+  else
+    return contains(path, "/setonix-q/")
+      or contains(path, "/neoverse_v2/")
+      or contains(path, "/zen3/")
+  end
+end
 
--- Add SHPC modules to MODULEPATH
-local psc_sw_env_shpc_root = psc_sw_env_root_dir .. "/" .. psc_sw_env_shpc_containers_modules_dir
-prepend_path("MODULEPATH", psc_sw_env_shpc_root)
+local function discard_stale_path(var, path)
+  if current_mode == "unload" then
+    -- Lmod reverses modulefile operations while unloading.
+    prepend_path(var, path)
+  else
+    remove_path(var, path)
+  end
+end
 
+local function clean_path_variable(var, value)
+  for path in string.gmatch(value or "", "[^:]+") do
+    if is_stale_partition_path(path) then
+      discard_stale_path(var, path)
+    end
+  end
+end
 
--- Add Pawsey custom modules to Cray Lmod hierarchy variables
-local psc_sw_env_custom_modules_root = psc_sw_env_root_dir .. "/" .. psc_sw_env_custom_modules_dir .. "/" .. arch
-prepend_path("LMOD_CUSTOM_COMPILER_GNU_12_0_PREFIX", psc_sw_env_custom_modules_root .. "/gcc/" .. psc_sw_env_gcc_version .. "/" .. psc_sw_env_custom_modules_suffix)
-prepend_path("LMOD_CUSTOM_COMPILER_CRAYCLANG_17_0_PREFIX", psc_sw_env_custom_modules_root .. "/cce/" .. psc_sw_env_cce_version .. "/" .. psc_sw_env_custom_modules_suffix)
-prepend_path("LMOD_CUSTOM_COMPILER_AOCC_4_1_PREFIX", psc_sw_env_custom_modules_root .. "/aocc/" .. psc_sw_env_aocc_version .. "/" .. psc_sw_env_custom_modules_suffix)
+if current_mode == "load" or current_mode == "unload" then
+  clean_path_variable("MODULEPATH", os.getenv("MODULEPATH"))
+  clean_path_variable("LMOD_PACKAGE_PATH", os.getenv("LMOD_PACKAGE_PATH"))
 
--- Let scripts know which version of the software stack is loaded
-setenv("PAWSEY_STACK_VERSION", "DATE_TAG")
+  -- Compiler aliases vary between CPE releases, so inspect the active aliases
+  -- instead of embedding aliases from another node image in this modulefile.
+  local environment = subprocess("env") or ""
+  for line in string.gmatch(environment, "[^\n]+") do
+    local name, value = string.match(line, "^([^=]+)=(.*)$")
+    if name and string.match(
+      name,
+      "^LMOD_CUSTOM_COMPILER_[A-Z0-9_]+_PREFIX$"
+    ) then
+      clean_path_variable(name, value)
+    end
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Path Registration Helpers
+--------------------------------------------------------------------------------
+local function join_path(...)
+  return table.concat({...}, "/")
+end
+
+local function prepend_compiler_paths(base_path, suffix)
+  for _, compiler in ipairs(compilers) do
+    prepend_path(
+      compiler.var,
+      join_path(base_path, compiler.dir, compiler.version, suffix)
+    )
+  end
+end
+
+--------------------------------------------------------------------------------
+-- Apply Module Paths
+--------------------------------------------------------------------------------
+setenv("PAWSEY_STACK_VERSION", date_tag)
+setenv("PAWSEYENV_ARCH", arch)
+
+prepend_path("LMOD_PACKAGE_PATH", "/software/" .. system .. "/lmod-extras")
+
+local project_file = assert(io.open(os.getenv("HOME") .. "/.pawsey_project", "r"))
+local project = project_file:read("*l")
+project_file:close()
+setenv("PAWSEY_PROJECT", project)
+
+local system_stack = join_path(system, date_tag)
+
+-- User modules
+local user_modules_root = join_path(
+  user_permanent_files_prefix, project, user, system_stack, "modules", arch
+)
+prepend_compiler_paths(user_modules_root, user_modules_suffix)
+
+-- User SHPC containers
+local user_shpc_root = join_path(
+  user_permanent_files_prefix, project, user, system_stack, shpc_modules_dir
+)
+prepend_path("MODULEPATH", user_shpc_root)
+
+-- Project SHPC containers
+local project_shpc_root = join_path(
+  user_permanent_files_prefix, project, system_stack, shpc_modules_dir
+)
+prepend_path("MODULEPATH", project_shpc_root)
+
+-- Project modules
+local project_modules_root = join_path(
+  user_permanent_files_prefix, project, system_stack, "modules", arch
+)
+prepend_compiler_paths(project_modules_root, project_modules_suffix)
+
+-- Utility modules
+prepend_path("MODULEPATH", join_path(install_prefix, utilities_modules_dir))
+
+-- Spack modules
+local spack_root = join_path(install_prefix, "modules", arch)
+for _, category in ipairs(module_categories) do
+  prepend_compiler_paths(spack_root, category)
+end
+
+-- System SHPC containers
+prepend_path("MODULEPATH", join_path(install_prefix, shpc_modules_dir))
+
+-- Custom modules
+local custom_modules_root = join_path(install_prefix, custom_modules_dir, arch)
+prepend_compiler_paths(custom_modules_root, custom_modules_suffix)
+
+local active_compiler = os.getenv("LMOD_FAMILY_COMPILER") or ""
+if current_mode == "load" and active_compiler ~= "" then
+  LmodWarning(
+    "A compiler environment is already loaded (", active_compiler, "). ",
+    "Reload the compiler or PrgEnv module to activate the ",
+    "architecture-specific module paths."
+  )
 end

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -217,10 +217,14 @@ local custom_modules_root = join_path(install_prefix, custom_modules_dir, arch)
 prepend_compiler_paths(custom_modules_root, custom_modules_suffix)
 
 local active_compiler = os.getenv("LMOD_FAMILY_COMPILER") or ""
-if current_mode == "load" and active_compiler ~= "" then
+local pawseyenv_is_loading = isPending(myModuleFullName())
+if current_mode == "load"
+  and pawseyenv_is_loading
+  and active_compiler ~= ""
+then
   LmodWarning(
     "A compiler environment is already loaded (", active_compiler, "). ",
-    "Reload the compiler or PrgEnv module to activate the ",
+    "Run 'module refresh' to activate the ",
     "architecture-specific module paths."
   )
 end

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -136,16 +136,9 @@ if current_mode == "load" or current_mode == "unload" then
   end
 end
 
---------------------------------------------------------------------------------
--- Path Registration Helpers
---------------------------------------------------------------------------------
-local function join_path(...)
-  return table.concat({...}, "/")
-end
-
 local function prepend_compiler_paths(base_path, suffix)
   for _, compiler in ipairs(compilers) do
-    local path = join_path(base_path, compiler.dir, compiler.version, suffix)
+    local path = pathJoin(base_path, compiler.dir, compiler.version, suffix)
     if isDir(path) then
       prepend_path(compiler.var, path)
     end
@@ -165,46 +158,46 @@ local project = project_file:read("*l")
 project_file:close()
 setenv("PAWSEY_PROJECT", project)
 
-local system_stack = join_path(system, date_tag)
+local system_stack = pathJoin(system, date_tag)
 
 -- User modules
-local user_modules_root = join_path(
+local user_modules_root = pathJoin(
   user_permanent_files_prefix, project, user, system_stack, "modules", arch
 )
 prepend_compiler_paths(user_modules_root, user_modules_suffix)
 
 -- User SHPC containers
-local user_shpc_root = join_path(
+local user_shpc_root = pathJoin(
   user_permanent_files_prefix, project, user, system_stack, shpc_modules_dir
 )
 prepend_path("MODULEPATH", user_shpc_root)
 
 -- Project SHPC containers
-local project_shpc_root = join_path(
+local project_shpc_root = pathJoin(
   user_permanent_files_prefix, project, system_stack, shpc_modules_dir
 )
 prepend_path("MODULEPATH", project_shpc_root)
 
 -- Project modules
-local project_modules_root = join_path(
+local project_modules_root = pathJoin(
   user_permanent_files_prefix, project, system_stack, "modules", arch
 )
 prepend_compiler_paths(project_modules_root, project_modules_suffix)
 
 -- Utility modules
-prepend_path("MODULEPATH", join_path(install_prefix, utilities_modules_dir))
+prepend_path("MODULEPATH", pathJoin(install_prefix, utilities_modules_dir))
 
 -- Spack modules
-local spack_root = join_path(install_prefix, "modules", arch)
+local spack_root = pathJoin(install_prefix, "modules", arch)
 for _, category in ipairs(module_categories) do
   prepend_compiler_paths(spack_root, category)
 end
 
 -- System SHPC containers
-prepend_path("MODULEPATH", join_path(install_prefix, shpc_modules_dir))
+prepend_path("MODULEPATH", pathJoin(install_prefix, shpc_modules_dir))
 
 -- Custom modules
-local custom_modules_root = join_path(install_prefix, custom_modules_dir, arch)
+local custom_modules_root = pathJoin(install_prefix, custom_modules_dir, arch)
 prepend_compiler_paths(custom_modules_root, custom_modules_suffix)
 
 local active_compiler = os.getenv("LMOD_FAMILY_COMPILER") or ""

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -154,10 +154,10 @@ end
 
 local function prepend_compiler_paths(base_path, suffix)
   for _, compiler in ipairs(compilers) do
-    prepend_path(
-      compiler.var,
-      join_path(base_path, compiler.dir, compiler.version, suffix)
-    )
+    local path = join_path(base_path, compiler.dir, compiler.version, suffix)
+    if isDir(path) then
+      prepend_path(compiler.var, path)
+    end
   end
 end
 

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -224,7 +224,6 @@ if current_mode == "load"
 then
   LmodWarning(
     "A compiler environment is already loaded (", active_compiler, "). ",
-    "Run 'module refresh' to activate the ",
-    "architecture-specific module paths."
+    "Run 'module refresh' to activate the architecture-specific module paths."
   )
 end

--- a/scripts/templates/pawseyenv.lua
+++ b/scripts/templates/pawseyenv.lua
@@ -110,19 +110,10 @@ local function is_stale_partition_path(path)
   end
 end
 
-local function discard_stale_path(var, path)
-  if current_mode == "unload" then
-    -- Lmod reverses modulefile operations while unloading.
-    prepend_path(var, path)
-  else
-    remove_path(var, path)
-  end
-end
-
 local function clean_path_variable(var, value)
   for path in string.gmatch(value or "", "[^:]+") do
     if is_stale_partition_path(path) then
-      discard_stale_path(var, path)
+      remove_path(var, path)
     end
   end
 end
@@ -217,6 +208,9 @@ local custom_modules_root = join_path(install_prefix, custom_modules_dir, arch)
 prepend_compiler_paths(custom_modules_root, custom_modules_suffix)
 
 local active_compiler = os.getenv("LMOD_FAMILY_COMPILER") or ""
+-- isPending() is true while this module is being loaded, but false when Lmod
+-- re-evaluates an already loaded module during `module refresh`.
+-- We use this here to prevent the warning from being displayed when refreshing.
 local pawseyenv_is_loading = isPending(myModuleFullName())
 if current_mode == "load"
   and pawseyenv_is_loading

--- a/systems/setonix/settings.sh
+++ b/systems/setonix/settings.sh
@@ -59,6 +59,15 @@ gcc_version="14.2.0"
 gcc_versionO="14.2.1"
 cce_version="21.0.0"
 aocc_version="5.1.0"
+# CPE 26.03 compiler aliases used in the LMOD_CUSTOM_COMPILER variable names.
+gcc_compat_version="13.0"
+cce_compat_version="21.0"
+aocc_compat_version="4.1"
+
+# The Setonix stack has no NVIDIA compiler module tree. 
+# Empty values used when generating the pawseyenv modulefile.
+nvidia_version=""
+nvidia_compat_version=""
 
 # architecture of login/compute nodes (needed by Singularity symlink module)
 cpu_arch="zen3"


### PR DESCRIPTION
This brings in the `pawseyenv` module template from `setonix-q-08-2026`. The main behaviour changes are:

- ARM and x86 architecture checks, support for architecture-specific compiler sets and path configuration

- Sets `PAWSEYENV_ARCH` to the selected architecture

- Adds NVIDIA compiler hierarchy support on ARM nodes. Restricts CCE and AOCC to Zen nodes

- Generates compiler variable names from a configured CPE compatibility version

- Cleans paths belonging to other partitions and architectures when loading or unloading, preventing module visibility from leaking between partitions

- Warns when `pawseyenv` is loaded after a compiler environment and directs the user to run `module refresh`.